### PR TITLE
Addressing issues 77, 78, and 81, where leading spaces and empty environment variables cause issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Test Functionality
+- Added test function - [`test_default_route_crud_operations.py - test_vpc_default_route_crud_operations_multiple_cidr_custom_destinations()`](./source/lambda/state_machine/__tests__/vpc_handler/test_default_route_crud_operations.py)
+    - Tests the case where there are multiple custom CIDR blocks with a leading space between commas
+- Added test function - [`test_default_route_crud_operations.py - test_vpc_default_route_crud_operations_multiple_pls_custom_destinations()`](./source/lambda/state_machine/__tests__/vpc_handler/test_default_route_crud_operations.py)
+    - Tests the case where there are multiple prefix list IDs with a leading space between commas
+
+### Changed
+
+#### Core Functionality 
+- Changed function - [`vpc_handler.py - _update_route_table_with_cidr_blocks()`](./source/lambda/state_machine/lib/handlers/vpc_handler.py)
+    - Added `lstrip()` to routes to move leading white spaces enforced by the [`network-orchestration-hub.template's`](./deployment/network-orchestration-hub.template) `AllowedPattern` on the `ListOfCustomCidrBlocks` parameter
+    - Added `and '' not in prefix_lists` and `and '' not in cidr_blocks` checks to account for empty environment variables (moto doesn't seem to catch this)
+
+#### Test Functionality
+- Changed test function - [`conftest.py - override_environment_variables()`](./source/lambda/state_machine/__tests__/conftest.py) 
+    - Default Environment Variables changes for `os.environ['PREFIX_LISTS']`:
+        - Syntax changed to match prefix syntax
+        - Changed to only one entry - multiple entries are now environment overrides in the tests
+- Changed test function - [`test_default_route_crud_operations.py - test_vpc_default_route_crud_operations_custom_destinations()`](./source/lambda/state_machine/__tests__/vpc_handler/test_default_route_crud_operations.py)
+    - Added `Action` and `RouteTableId` to the test event.
+
+# [3.2.2] - 2023-04-14
+
+### Added
+
 - ObjectWriter ownership control to logs bucket, in response to S3 service change
 
 ## [3.2.1] - 2023-01-13

--- a/source/lambda/state_machine/__tests__/conftest.py
+++ b/source/lambda/state_machine/__tests__/conftest.py
@@ -29,7 +29,7 @@ def override_environment_variables():
     os.environ['TABLE_NAME'] = TABLE_NAME
     os.environ['TTL'] = '90'
     os.environ['CIDR_BLOCKS'] = '10.0.0.0/26'
-    os.environ['PREFIX_LISTS'] = '10,11'
+    os.environ['PREFIX_LISTS'] = 'pl-11111'
     os.environ['ASSOCIATION_TAG'] = 'Associate-with'
     os.environ['ATTACHMENT_TAG'] = 'Attach-to'
     os.environ['PROPAGATION_TAG'] = 'Propagate-to'

--- a/source/lambda/state_machine/__tests__/vpc_handler/test_default_route_crud_operations.py
+++ b/source/lambda/state_machine/__tests__/vpc_handler/test_default_route_crud_operations.py
@@ -143,7 +143,9 @@ def test_vpc_default_route_crud_operations_custom_destinations(vpc_setup):
     event = {
         'SubnetId': vpc_setup['subnet_id'],
         'account': '123456789012',
-        'region': 'us-east-1'
+        'region': 'us-east-1',
+        'Action': 'AddSubnet',
+        'RouteTableId': vpc_setup['route_table_id']
     }
 
     # ACT
@@ -157,6 +159,57 @@ def test_vpc_default_route_crud_operations_custom_destinations(vpc_setup):
     # ASSERT
     assert response['SubnetId'] == vpc_setup['subnet_id']
 
+@mock_sts
+def test_vpc_default_route_crud_operations_multiple_cidr_custom_destinations(vpc_setup):
+    # ARRANGE
+    override_environment_variables()
+    os.environ['DEFAULT_ROUTE'] = 'Custom-Destinations'
+    os.environ['CIDR_BLOCKS'] = '10.0.0.0/26, 10.0.1.0/26'
+
+    event = {
+        'SubnetId': vpc_setup['subnet_id'],
+        'account': '123456789012',
+        'region': 'us-east-1',
+        'Action': 'AddSubnet',
+        'RouteTableId': vpc_setup['route_table_id']
+    }
+
+    # ACT
+    response = lambda_handler({
+        'params': {
+            'ClassName': 'VPC',
+            'FunctionName': 'default_route_crud_operations'
+        },
+        'event': event}, LambdaContext())
+
+    # ASSERT
+    assert response['SubnetId'] == vpc_setup['subnet_id']
+
+@mock_sts
+def test_vpc_default_route_crud_operations_multiple_pls_custom_destinations(vpc_setup):
+    # ARRANGE
+    override_environment_variables()
+    os.environ['DEFAULT_ROUTE'] = 'Custom-Destinations'
+    os.environ['PREFIX_LISTS'] = 'pl-11111, pl-22222'
+
+    event = {
+        'SubnetId': vpc_setup['subnet_id'],
+        'account': '123456789012',
+        'region': 'us-east-1',
+        'Action': 'AddSubnet',
+        'RouteTableId': vpc_setup['route_table_id']
+    }
+
+    # ACT
+    response = lambda_handler({
+        'params': {
+            'ClassName': 'VPC',
+            'FunctionName': 'default_route_crud_operations'
+        },
+        'event': event}, LambdaContext())
+
+    # ASSERT
+    assert response['SubnetId'] == vpc_setup['subnet_id']
 
 @mock_sts
 def test_vpc_default_route_crud_operations_configure_manually(vpc_setup):

--- a/source/lambda/state_machine/lib/handlers/vpc_handler.py
+++ b/source/lambda/state_machine/lib/handlers/vpc_handler.py
@@ -650,7 +650,6 @@ class VPC:
 
                 elif "Configure-Manually" in environ.get("DEFAULT_ROUTE"):
                     self.logger.info("Admin opted to configure route table manually")
-
             return self.event
 
         except Exception as e:
@@ -660,16 +659,18 @@ class VPC:
 
     def _update_route_table_with_cidr_blocks(self, ec2, existing_routes):
         cidr_blocks = environ.get("CIDR_BLOCKS").split(',')
-        if len(cidr_blocks) > 0:
+        if len(cidr_blocks) > 0 and '' not in cidr_blocks:
             for route in cidr_blocks:
+                route = route.lstrip()
                 self.logger.info(f"Adding route: {route}")
                 self._find_existing_default_route(existing_routes, route)
                 self._update_route_table(ec2, route)
 
     def _update_route_table_with_prefix_lists(self, ec2, existing_routes):
         prefix_lists = environ.get("PREFIX_LISTS").split(',')
-        if len(prefix_lists) > 0:
+        if len(prefix_lists) > 0 and '' not in prefix_lists:
             for prefix_list_id in prefix_lists:
+                prefix_list_id = prefix_list_id.lstrip()
                 self.logger.info(f"Adding prefix list id: {prefix_list_id}")
                 self._find_existing_default_route(
                     existing_routes, prefix_list_id


### PR DESCRIPTION
Addressing issues 77, 78, and 81, where leading spaces and empty environment variables cause issues

*Issue #, if available:*
- [77](https://github.com/aws-solutions/network-orchestration-for-aws-transit-gateway/issues/77)
- [78](https://github.com/aws-solutions/network-orchestration-for-aws-transit-gateway/issues/78)
- [81](https://github.com/aws-solutions/network-orchestration-for-aws-transit-gateway/issues/81)

*Description of changes:*
Details in the [CHANGELOG](https://github.com/aws-solutions/network-orchestration-for-aws-transit-gateway/compare/main...mc-etcher:network-orchestration-for-aws-transit-gateway:issue-77-78-81-remeditation?expand=1#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed)
- Updated VPC Handler:
    - Removes leading spaces for each item in the  `ListOfCustomCidrBlocks` and `CustomerManagedPrefixListIds` variables
    - Handles empty environment variables
- Added tests to account for leading spaces in the `ListOfCustomCidrBlocks` and `CustomerManagedPrefixListIds` variables
- Addressed a case where the `test_vpc_default_route_crud_operations_custom_destinations` wasn't adding a subnet
- Changed default values for tests in `override_environment_variables()`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
