### PR TITLE
add new transit gateway supported regions

### DIFF
--- a/deployment/network-orchestration-hub.template
+++ b/deployment/network-orchestration-hub.template
@@ -354,6 +354,10 @@ Mappings:
       AmazonSideAsn: 64542 # this must be changed by a network admin only
     eu-north-1:
       AmazonSideAsn: 64543 # this must be changed by a network admin only
+    af-south-1:
+      AmazonSideAsn: 64544 # this must be changed by a network admin only
+    me-south-1:
+      AmazonSideAsn: 64545 # this must be changed by a network admin only - should be unique and between numbers 64512 to 65534
   NotificationConfiguration:
     SNS:
       DisplayName: "AWS Transit Network Change Approval Notification"


### PR DESCRIPTION
*Issue #, if available:*
none
*Description of changes:*
This changes specifically focuses on including new transit gateway supported regions which are not yet reflected on the hub template . Very recently had to support a customer for the cape town region for which the hub templates failed deploy hence the changes 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
