### PR TITLE
Combine Spoke and Service Linked Role stack into one with conditions

### DIFF
--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -104,9 +104,10 @@ cd ../..
 headline "[Stage] Copy templates to global-s3-assets directory"
 cp -f $template_dir/network-orchestration-hub.template $template_dist_dir
 cp -f $template_dir/network-orchestration-spoke.template $template_dist_dir
+cp -f $template_dir/network-orchestration-spoke-nested.template $template_dist_dir
 cp -f $template_dir/network-orchestration-organization-role.template $template_dist_dir
 cp -f $template_dir/network-orchestration-hub-service-linked-roles.template $template_dist_dir
-cp -f $template_dir/network-orchestration-spoke-service-linked-roles.template $template_dist_dir
+cp -f $template_dir/network-orchestration-spoke-service-linked-roles-nested.template $template_dist_dir
 
 # Find and replace bucket_name, solution_name, and version
 if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -115,48 +116,54 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     replace="s/%DIST_BUCKET_NAME%/$1/g"
     sed -i '' -e $replace $template_dist_dir/network-orchestration-hub.template
     sed -i '' -e $replace $template_dist_dir/network-orchestration-spoke.template
+    sed -i '' -e $replace $template_dist_dir/network-orchestration-spoke-nested.template
     sed -i '' -e $replace $template_dist_dir/network-orchestration-organization-role.template
     sed -i '' -e $replace $template_dist_dir/network-orchestration-hub-service-linked-roles.template
-    sed -i '' -e $replace $template_dist_dir/network-orchestration-spoke-service-linked-roles.template
+    sed -i '' -e $replace $template_dist_dir/network-orchestration-spoke-service-linked-roles-nested.template
 
     # Replace solution name with real value
     replace="s/%SOLUTION_NAME%/$2/g"
     sed -i '' -e $replace $template_dist_dir/network-orchestration-hub.template
     sed -i '' -e $replace $template_dist_dir/network-orchestration-spoke.template
+    sed -i '' -e $replace $template_dist_dir/network-orchestration-spoke-nested.template
     sed -i '' -e $replace $template_dist_dir/network-orchestration-organization-role.template
     sed -i '' -e $replace $template_dist_dir/network-orchestration-hub-service-linked-roles.template
-    sed -i '' -e $replace $template_dist_dir/network-orchestration-spoke-service-linked-roles.template
+    sed -i '' -e $replace $template_dist_dir/network-orchestration-spoke-service-linked-roles-nested.template
 
     # Replace version variable with real value
     replace="s/%VERSION%/$3/g"
     sed -i '' -e $replace $template_dist_dir/network-orchestration-hub.template
     sed -i '' -e $replace $template_dist_dir/network-orchestration-spoke.template
+    sed -i '' -e $replace $template_dist_dir/network-orchestration-spoke-nested.template
     sed -i '' -e $replace $template_dist_dir/network-orchestration-organization-role.template
     sed -i '' -e $replace $template_dist_dir/network-orchestration-hub-service-linked-roles.template
-    sed -i '' -e $replace $template_dist_dir/network-orchestration-spoke-service-linked-roles.template
+    sed -i '' -e $replace $template_dist_dir/network-orchestration-spoke-service-linked-roles-nested.template
 else
     # Other linux
     # Replace source code s3 bucket name with real value
     replace="s/%DIST_BUCKET_NAME%/$1/g"
     sed -i -e $replace $template_dist_dir/network-orchestration-hub.template
     sed -i -e $replace $template_dist_dir/network-orchestration-spoke.template
+    sed -i -e $replace $template_dist_dir/network-orchestration-spoke-nested.template
     sed -i -e $replace $template_dist_dir/network-orchestration-organization-role.template
     sed -i -e $replace $template_dist_dir/network-orchestration-hub-service-linked-roles.template
-    sed -i -e $replace $template_dist_dir/network-orchestration-spoke-service-linked-roles.template
+    sed -i -e $replace $template_dist_dir/network-orchestration-spoke-service-linked-roles-nested.template
 
     # Replace solution name with real value
     replace="s/%SOLUTION_NAME%/$2/g"
     sed -i -e $replace $template_dist_dir/network-orchestration-hub.template
     sed -i -e $replace $template_dist_dir/network-orchestration-spoke.template
+    sed -i -e $replace $template_dist_dir/network-orchestration-spoke-nested.template
     sed -i -e $replace $template_dist_dir/network-orchestration-organization-role.template
     sed -i -e $replace $template_dist_dir/network-orchestration-hub-service-linked-roles.template
-    sed -i -e $replace $template_dist_dir/network-orchestration-spoke-service-linked-roles.template
+    sed -i -e $replace $template_dist_dir/network-orchestration-spoke-service-linked-roles-nested.template
 
     # Replace version variable with real value
     replace="s/%VERSION%/$3/g"
     sed -i -e $replace $template_dist_dir/network-orchestration-hub.template
     sed -i -e $replace $template_dist_dir/network-orchestration-spoke.template
+    sed -i -e $replace $template_dist_dir/network-orchestration-spoke-nested.template
     sed -i -e $replace $template_dist_dir/network-orchestration-organization-role.template
     sed -i -e $replace $template_dist_dir/network-orchestration-hub-service-linked-roles.template
-    sed -i -e $replace $template_dist_dir/network-orchestration-spoke-service-linked-roles.template
+    sed -i -e $replace $template_dist_dir/network-orchestration-spoke-service-linked-roles-nested.template
 fi

--- a/deployment/network-orchestration-spoke-nested.template
+++ b/deployment/network-orchestration-spoke-nested.template
@@ -1,0 +1,287 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+AWSTemplateFormatVersion: "2010-09-09"
+Description: (SO0058sn) - The AWS CloudFormation template (Spoke) for deployment of the %SOLUTION_NAME% Solution. Version %VERSION%
+
+Parameters:
+  HubAccount:
+    Description: Account Id for the network hub account, eg. 123456789012
+    Type: String
+    AllowedPattern: ^\d{12}$
+
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Account ID of the network account where Transit Gateway resides.
+        Parameters:
+          - HubAccount
+    ParameterLabels:
+      HubAccount:
+        default: Network (Hub) Account
+      CreateServiceRoleForVPCTransitGateway:
+        default: Skip the creation of AWSServiceRoleForVPCTransitGateway
+
+Mappings:
+  EventBridge:
+    Bus:
+      Name: "Network-Orchestrator-Event-Bus"
+  SourceCode:
+    General:
+      S3Bucket: "%DIST_BUCKET_NAME%"
+      KeyPrefix: "network-orchestration-for-aws-transit-gateway/%VERSION%"
+      Version: "%VERSION%"
+  LambdaFunction:
+    Logging:
+      Level: "info"
+      
+Conditions:
+  # Adding an EventBus as a target within an account is not allowed.
+  IsSpokeAccountOtherThanHubAccount: !Not [ !Equals [ !Ref HubAccount, !Ref "AWS::AccountId" ] ]
+
+Resources:
+  #
+  # Serverless Transit Network Orchestrator Cloudwatch Event Rule
+  #
+  TagEventRule:
+    Condition: "IsSpokeAccountOtherThanHubAccount"  # Adding an EventBus as a target within an account is not allowed.
+    Type: AWS::Events::Rule
+    Properties:
+      Description: Serverless Transit Network Orchestrator - Spoke - Rule for tag on resource events
+      EventPattern:
+        {
+          "account": [
+            !Ref "AWS::AccountId"
+          ],
+          "source": [
+            "aws.tag"
+          ],
+          "detail-type": [
+            "Tag Change on Resource"
+          ],
+          "detail": {
+            "service": [
+              "ec2"
+            ],
+            "resource-type": [
+              "subnet",
+              "vpc"
+            ]
+          }
+        }
+      State: ENABLED
+      Targets:
+        - Arn: !Sub
+            - arn:${AWS::Partition}:events:${AWS::Region}:${HubAccount}:event-bus/${EventBusName}
+            - {EventBusName: !FindInMap [EventBridge, Bus, Name]}
+          Id: SpokeSubnetTagEvent
+          RoleArn: !GetAtt TransitNetworkEventDeliveryRole.Arn
+
+
+  SubnetDeletionEventRule:
+    Condition: "IsSpokeAccountOtherThanHubAccount"  # Adding an EventBus as a target within an account is not allowed.
+    Type: AWS::Events::Rule
+    Properties:
+      Description: Serverless Transit Network Orchestrator - Spoke - Rule for subnet deletion
+      EventPattern:
+        {
+          "account": [
+            !Ref "AWS::AccountId"
+          ],
+          "source": [
+            "aws.ec2"
+          ],
+          "detail-type": [
+            "AWS API Call via CloudTrail"
+          ],
+          "detail": {
+            "eventSource": [
+              "ec2.amazonaws.com"
+            ],
+            "eventName": [
+              "DeleteSubnet"
+            ],
+            "errorCode": [
+              "Client.DependencyViolation"
+            ],
+            "sourceIPAddress": [
+              "cloudformation.amazonaws.com"
+            ]
+          }
+        }
+      State: ENABLED
+      Targets:
+        - Arn: !Sub
+            - arn:${AWS::Partition}:events:${AWS::Region}:${HubAccount}:event-bus/${EventBusName}
+            - {EventBusName: !FindInMap [EventBridge, Bus, Name]}
+          Id: SpokeSubnetTagEvent
+          RoleArn: !GetAtt TransitNetworkEventDeliveryRole.Arn
+
+
+  # IAM Role for Serverless Transit Network Orchestrator Execution in the Spoke account
+  TransitNetworkExecutionRole:
+    Type: AWS::IAM::Role
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+            reason: "The role name 'TransitNetworkExecutionRole-<AWS-REGION>' has to be defined to allow cross account access from the hub account to make network changes."
+          - id: W11
+            reason: "Allow * because it is required for making Describe and GetResourceShareInvitationsAPI calls as they don't support resource-level permissions and require you to choose All resources."
+    Properties:
+      RoleName: !Join ["-", ["TransitNetworkExecutionRole", Ref: "AWS::Region"]]
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS:
+                - !Join ['', ['arn:', !Ref 'AWS::Partition', ':iam::', !Ref HubAccount, ':role/STNO-StateMachineLambdaFunctionRole', '-', !Ref 'AWS::Region']]
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: TransitNetworkExecutionPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ec2:CreateTransitGatewayRoute
+                  - ec2:DeleteTransitGatewayRoute
+                  - ec2:ModifyTransitGatewayVpcAttachment
+                  - ec2:CreateTransitGatewayVpcAttachment
+                  - ec2:DeleteTransitGatewayVpcAttachment
+                  - ec2:CreateRoute
+                  - ec2:DeleteRoute
+                  - ec2:CreateTags
+                Resource:
+                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:transit-gateway-route-table/*
+                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:transit-gateway-attachment/*
+                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:vpc/*
+                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:subnet/*
+                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:route-table/*
+                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${HubAccount}:transit-gateway/*
+              - Effect: Allow
+                Action:
+                  - ec2:CreateRoute
+                  - ec2:DeleteRoute
+                  - ec2:CreateTags
+                Resource:
+                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:vpc/*
+                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:subnet/*
+                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:route-table/*
+              - Effect: Allow
+                Action:
+                  - ec2:DescribeTransitGatewayVpcAttachments
+                  - ec2:DescribeTransitGatewayAttachments
+                  - ec2:DescribeTransitGatewayRouteTables
+                  - ec2:DescribeVpcs
+                  - ec2:DescribeRegions
+                  - ec2:DescribeSubnets
+                  - ec2:DescribeRouteTables
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - ram:GetResourceShareInvitations
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - ram:AcceptResourceShareInvitation
+                Resource: !Sub arn:${AWS::Partition}:ram:${AWS::Region}:${HubAccount}:resource-share-invitation/*
+
+
+  # IAM Role for Event Rule in the Spoke account to invoke event bus in hub account
+  # This role is only needed if the spoke account belongs to an AWS Organization
+  TransitNetworkEventDeliveryRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+                Service: events.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: TransitNetworkEventBusDeliveryRolePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - events:PutEvents
+                Resource: !Sub
+                  - arn:${AWS::Partition}:events:${AWS::Region}:${HubAccount}:event-bus/${EventBusName}
+                  - {EventBusName: !FindInMap [EventBridge, Bus, Name]}
+
+  # Lambda to check if the Transit Gateway service linked role already exist
+  ServiceLinkedRoleCheckLambdaFunction:
+    Type: AWS::Lambda::Function
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W92
+            reason: "does not require concurrency reservation"
+          - id: W89
+            reason: "not a valid use-case for vpc"
+          - id: W58
+            reason: "log write permission added to CustomResourceLambdaFunctionRole"
+    Properties:
+      Environment:
+        Variables:
+          LOG_LEVEL: !FindInMap [LambdaFunction, Logging, Level]
+          PARTITION: !Sub ${AWS::Partition}
+      Code:
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], !Ref "AWS::Region"]]
+        S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],"custom_resource.zip"]]
+      Description: Network Orchestration for AWS Transit Gateway - custom resource handler
+      Handler: custom_resource.main.lambda_handler
+      MemorySize: 512
+      Role: !Sub ${CustomResourceLambdaFunctionRole.Arn}
+      Runtime: python3.11
+      Timeout: 900
+
+  CustomResourceLambdaFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: STNO-CWLogs-Policy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*
+        - PolicyName: STNO-IAM-Policy
+          PolicyDocument: 
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - iam:GetRole
+                Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*
+
+  CheckServiceLinkedRole:
+    Type: "Custom::CheckServiceLinkedRole"
+    Properties:
+      ServiceToken: !GetAtt ServiceLinkedRoleCheckLambdaFunction.Arn
+
+Outputs:
+  ServiceLinkedRoleExist:
+    Value: !GetAtt CheckServiceLinkedRole.ServiceLinkedRoleExist

--- a/deployment/network-orchestration-spoke-service-linked-roles-nested.template
+++ b/deployment/network-orchestration-spoke-service-linked-roles-nested.template
@@ -2,15 +2,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
 AWSTemplateFormatVersion: "2010-09-09"
-Description: (SO0058s-slr) - The AWS CloudFormation template (Spoke) for deployment of the %SOLUTION_NAME% Solution. Version %VERSION%
+Description: (SO0058s-slrn) - The AWS CloudFormation template (Spoke) for deployment of the %SOLUTION_NAME% Solution. Version %VERSION%
+
+Parameters:
+  ServiceLinkedRoleExist:
+    Type: String
+    Description: Does the service-linked role for AWS Transit Gateway already exist?
+    Default: "False"
+
+Conditions:
+  CreateServiceLinkedRole: !Equals [ !Ref ServiceLinkedRoleExist, "False" ]  
 
 Resources:
   TransitGatewayServiceLinkedRole:
     Type: "AWS::IAM::ServiceLinkedRole"
+    Condition: CreateServiceLinkedRole
     Properties:
       AWSServiceName: "transitgateway.amazonaws.com"
       Description: Allows VPC Transit Gateway to access EC2 resources on your behalf.
 
 Outputs:
   TransitGatewayServiceLinkedRoleName:
+    Condition: CreateServiceLinkedRole
     Value: !Ref TransitGatewayServiceLinkedRole

--- a/deployment/network-orchestration-spoke.template
+++ b/deployment/network-orchestration-spoke.template
@@ -10,203 +10,31 @@ Parameters:
     Type: String
     AllowedPattern: ^\d{12}$
 
-
-Metadata:
-  AWS::CloudFormation::Interface:
-    ParameterGroups:
-      - Label:
-          default: Account ID of the network account where Transit Gateway resides.
-        Parameters:
-          - HubAccount
-    ParameterLabels:
-      HubAccount:
-        default: Network (Hub) Account
-      CreateServiceRoleForVPCTransitGateway:
-        default: Skip the creation of AWSServiceRoleForVPCTransitGateway
-
 Mappings:
-  EventBridge:
-    Bus:
-      Name: "Network-Orchestrator-Event-Bus"
-
-Conditions:
-  # Adding an EventBus as a target within an account is not allowed.
-  IsSpokeAccountOtherThanHubAccount: !Not [ !Equals [ !Ref HubAccount, !Ref "AWS::AccountId" ] ]
+  SourceCode:
+    General:
+      S3Bucket: "%DIST_BUCKET_NAME%"
+      KeyPrefix: "network-orchestration-for-aws-transit-gateway/%VERSION%"
+      Version: "%VERSION%"
 
 Resources:
-  #
-  # Serverless Transit Network Orchestrator Cloudwatch Event Rule
-  #
-  TagEventRule:
-    Condition: "IsSpokeAccountOtherThanHubAccount"  # Adding an EventBus as a target within an account is not allowed.
-    Type: AWS::Events::Rule
+  SpokeNestedStack:
+    Type: 'AWS::CloudFormation::Stack'
     Properties:
-      Description: Serverless Transit Network Orchestrator - Spoke - Rule for tag on resource events
-      EventPattern:
-        {
-          "account": [
-            !Ref "AWS::AccountId"
-          ],
-          "source": [
-            "aws.tag"
-          ],
-          "detail-type": [
-            "Tag Change on Resource"
-          ],
-          "detail": {
-            "service": [
-              "ec2"
-            ],
-            "resource-type": [
-              "subnet",
-              "vpc"
-            ]
-          }
-        }
-      State: ENABLED
-      Targets:
-        - Arn: !Sub
-            - arn:${AWS::Partition}:events:${AWS::Region}:${HubAccount}:event-bus/${EventBusName}
-            - {EventBusName: !FindInMap [EventBridge, Bus, Name]}
-          Id: SpokeSubnetTagEvent
-          RoleArn: !GetAtt TransitNetworkEventDeliveryRole.Arn
+      TemplateURL: !Sub
+                    - "https://${Bucket}.s3.amazonaws.com/${Prefix}/network-orchestration-spoke-nested.template"
+                    - Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], !Ref "AWS::Region"]]
+                      Prefix: !FindInMap ["SourceCode", "General", "KeyPrefix"]
+      Parameters:
+        HubAccount: !Ref HubAccount
 
-
-  SubnetDeletionEventRule:
-    Condition: "IsSpokeAccountOtherThanHubAccount"  # Adding an EventBus as a target within an account is not allowed.
-    Type: AWS::Events::Rule
+  ServiceLinkedRoleNestedStack:
+    Type: 'AWS::CloudFormation::Stack'
     Properties:
-      Description: Serverless Transit Network Orchestrator - Spoke - Rule for subnet deletion
-      EventPattern:
-        {
-          "account": [
-            !Ref "AWS::AccountId"
-          ],
-          "source": [
-            "aws.ec2"
-          ],
-          "detail-type": [
-            "AWS API Call via CloudTrail"
-          ],
-          "detail": {
-            "eventSource": [
-              "ec2.amazonaws.com"
-            ],
-            "eventName": [
-              "DeleteSubnet"
-            ],
-            "errorCode": [
-              "Client.DependencyViolation"
-            ],
-            "sourceIPAddress": [
-              "cloudformation.amazonaws.com"
-            ]
-          }
-        }
-      State: ENABLED
-      Targets:
-        - Arn: !Sub
-            - arn:${AWS::Partition}:events:${AWS::Region}:${HubAccount}:event-bus/${EventBusName}
-            - {EventBusName: !FindInMap [EventBridge, Bus, Name]}
-          Id: SpokeSubnetTagEvent
-          RoleArn: !GetAtt TransitNetworkEventDeliveryRole.Arn
-
-
-  # IAM Role for Serverless Transit Network Orchestrator Execution in the Spoke account
-  TransitNetworkExecutionRole:
-    Type: AWS::IAM::Role
-    Metadata:
-      cfn_nag:
-        rules_to_suppress:
-          - id: W28
-            reason: "The role name 'TransitNetworkExecutionRole-<AWS-REGION>' has to be defined to allow cross account access from the hub account to make network changes."
-          - id: W11
-            reason: "Allow * because it is required for making Describe and GetResourceShareInvitationsAPI calls as they don't support resource-level permissions and require you to choose All resources."
-    Properties:
-      RoleName: !Join ["-", ["TransitNetworkExecutionRole", Ref: "AWS::Region"]]
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              AWS:
-                - !Join ['', ['arn:', !Ref 'AWS::Partition', ':iam::', !Ref HubAccount, ':role/STNO-StateMachineLambdaFunctionRole', '-', !Ref 'AWS::Region']]
-            Action:
-              - sts:AssumeRole
-      Policies:
-        - PolicyName: TransitNetworkExecutionPolicy
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - ec2:CreateTransitGatewayRoute
-                  - ec2:DeleteTransitGatewayRoute
-                  - ec2:ModifyTransitGatewayVpcAttachment
-                  - ec2:CreateTransitGatewayVpcAttachment
-                  - ec2:DeleteTransitGatewayVpcAttachment
-                  - ec2:CreateRoute
-                  - ec2:DeleteRoute
-                  - ec2:CreateTags
-                Resource:
-                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:transit-gateway-route-table/*
-                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:transit-gateway-attachment/*
-                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:vpc/*
-                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:subnet/*
-                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:route-table/*
-                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${HubAccount}:transit-gateway/*
-              - Effect: Allow
-                Action:
-                  - ec2:CreateRoute
-                  - ec2:DeleteRoute
-                  - ec2:CreateTags
-                Resource:
-                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:vpc/*
-                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:subnet/*
-                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:route-table/*
-              - Effect: Allow
-                Action:
-                  - ec2:DescribeTransitGatewayVpcAttachments
-                  - ec2:DescribeTransitGatewayAttachments
-                  - ec2:DescribeTransitGatewayRouteTables
-                  - ec2:DescribeVpcs
-                  - ec2:DescribeRegions
-                  - ec2:DescribeSubnets
-                  - ec2:DescribeRouteTables
-                Resource: "*"
-              - Effect: Allow
-                Action:
-                  - ram:GetResourceShareInvitations
-                Resource: "*"
-              - Effect: Allow
-                Action:
-                  - ram:AcceptResourceShareInvitation
-                Resource: !Sub arn:${AWS::Partition}:ram:${AWS::Region}:${HubAccount}:resource-share-invitation/*
-
-
-  # IAM Role for Event Rule in the Spoke account to invoke event bus in hub account
-  # This role is only needed if the spoke account belongs to an AWS Organization
-  TransitNetworkEventDeliveryRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-                Service: events.amazonaws.com
-            Action:
-              - sts:AssumeRole
-      Path: /
-      Policies:
-        - PolicyName: TransitNetworkEventBusDeliveryRolePolicy
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action:
-                  - events:PutEvents
-                Resource: !Sub
-                  - arn:${AWS::Partition}:events:${AWS::Region}:${HubAccount}:event-bus/${EventBusName}
-                  - {EventBusName: !FindInMap [EventBridge, Bus, Name]}
-
+      TemplateURL: !Sub
+                    - "https://${Bucket}.s3.amazonaws.com/${Prefix}/network-orchestration-spoke-service-linked-roles-nested.template"
+                    - Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], !Ref "AWS::Region"]]
+                      Prefix: !FindInMap ["SourceCode", "General", "KeyPrefix"]
+      Parameters:
+        ServiceLinkedRoleExist: 
+          !GetAtt SpokeNestedStack.Outputs.ServiceLinkedRoleExist


### PR DESCRIPTION
*Issue #, if available: https://github.com/aws-solutions/network-orchestration-for-aws-transit-gateway/issues/123

*Description of changes:
1. Added spoke and service-linked-role templates as nested stacks of the new spoke template
2. Added a custom resource in the nested spoke template to check if the service linked role already exist
3. Added condition to service linked role template to only create service linked role if it doesnt currently exist
4. Added the service linked role check in the existing custom resource lambda code, and corresponding test cases

With this change, users only need to deploy the new spoke template, and the VPC Transit Gateway service-linked role will be created automatically if it doesn't exist, removing the need of the optional step - https://docs.aws.amazon.com/solutions/latest/network-orchestration-aws-transit-gateway/step-4-launch-the-service-linked-role-spoke-stack-optional.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
