### PR TITLE
Bump rollup to 2.79.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.10] - 2024-10-10
+
+### Security
+
+- Bumped rollup to `2.79.2` to mitigate [CVE-2024-47068](https://github.com/advisories/GHSA-gcx4-mw62-g8wm)
+
 ## [3.3.9] - 2024-09-16
 
 ### Security

--- a/source/cognito-trigger/package-lock.json
+++ b/source/cognito-trigger/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cognito-trigger",
-  "version": "3.3.9",
+  "version": "3.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cognito-trigger",
-      "version": "3.3.9",
+      "version": "3.3.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.102.0",

--- a/source/cognito-trigger/package.json
+++ b/source/cognito-trigger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cognito-trigger",
-  "version": "3.3.9",
+  "version": "3.3.10",
   "description": "Triggered when a new user is confirmed in the user pool to allow for custom actions to be taken",
   "author": {
     "name": "Amazon Web Services",

--- a/source/ui/package-lock.json
+++ b/source/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "network-orchestrator-for-aws-transit-gateway",
-  "version": "3.3.9",
+  "version": "3.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "network-orchestrator-for-aws-transit-gateway",
-      "version": "3.3.9",
+      "version": "3.3.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/auth": "^5.4.0",
@@ -29070,9 +29070,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "version": "2.79.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
+      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/source/ui/package.json
+++ b/source/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "network-orchestrator-for-aws-transit-gateway",
-  "version": "3.3.9",
+  "version": "3.3.10",
   "description": "Network Orchestration for AWS Transit Gateway(SO0058)",
   "license": "Apache-2.0",
   "author": {


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/aws-solutions/network-orchestration-for-aws-transit-gateway/pull/133

*Description of changes:*
- Bumped rollup to `2.79.2` to mitigate [CVE-2024-47068](https://github.com/advisories/GHSA-gcx4-mw62-g8wm)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
