### PR TITLE
Release 3.3.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.13] - 2025-02-06
+
+### Security
+
+- Bumped path-to-regexp to `0.1.12` to mitigate [CVE-2024-52798](https://github.com/advisories/GHSA-rhx6-c78j-4q9w)
+- Bumped nanoid to `3.3.8` to mitigate [CVE-2024-55565](https://github.com/advisories/GHSA-mwcw-c2x4-8c55)
+
 ## [3.3.12] - 2024-11-22
 
 ### Security

--- a/source/cognito-trigger/package-lock.json
+++ b/source/cognito-trigger/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cognito-trigger",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cognito-trigger",
-      "version": "3.3.12",
+      "version": "3.3.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.102.0",

--- a/source/cognito-trigger/package.json
+++ b/source/cognito-trigger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cognito-trigger",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "description": "Triggered when a new user is confirmed in the user pool to allow for custom actions to be taken",
   "author": {
     "name": "Amazon Web Services",

--- a/source/lambda/pyproject.toml
+++ b/source/lambda/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "network-orchestration-for-tgw"
-version = "3.3.11"
+version = "3.3.13"
 description = "solution packages for network-orchestration-for-tgw"
 requires-python = ">=3.10"
 license = { text = "Apache Software License" }

--- a/source/ui/package-lock.json
+++ b/source/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "network-orchestrator-for-aws-transit-gateway",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "network-orchestrator-for-aws-transit-gateway",
-      "version": "3.3.12",
+      "version": "3.3.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/auth": "^5.4.0",
@@ -17755,16 +17755,16 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -17778,7 +17778,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -17793,12 +17793,16 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -17825,9 +17829,9 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
     },
     "node_modules/external-editor": {
       "version": "3.1.0",
@@ -25672,9 +25676,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",

--- a/source/ui/package.json
+++ b/source/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "network-orchestrator-for-aws-transit-gateway",
-  "version": "3.3.12",
+  "version": "3.3.13",
   "description": "Network Orchestration for AWS Transit Gateway(SO0058)",
   "license": "Apache-2.0",
   "author": {


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*

- Bumped path-to-regexp to `0.1.12` to mitigate [CVE-2024-52798](https://github.com/advisories/GHSA-rhx6-c78j-4q9w)
- Bumped nanoid to `3.3.8` to mitigate [CVE-2024-55565](https://github.com/advisories/GHSA-mwcw-c2x4-8c55)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
