### PR TITLE
Release 3.3.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.15] - 2025-04-05
+
+### Security
+
+- Bump aws-amplify to `5.3.27`
+- Allow only TLS requests on S3 bucket through bucket policy
+- Add CSP security headers on CloudFront
+- Enable MFA for authentication by default
+- Add [AWS Managed WAF rules](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html) to ACL
+- Disable introspection queries on AppSync endpoint
+
+### Changed
+
+- Disable verbose logging on the AppSync endpoint
+- AppRegistry application tags at resource level
+
+### Fixed
+
+- Remove unused http methods from cache behavior, Cloudfront only needs to process and forward GET/HEAD requests to S3 origin
+- Improve error response for `UpdateTransitNetworkOrchestratorTable` API path
+
 ## [3.3.14] - 2025-03-14
 
 ### Security

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,61 +1,59 @@
-# Contributing Guidelines 
- 
-Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional 
-documentation, we greatly value feedback and contributions from our community. 
- 
-Please read through this document before submitting any issues or pull requests to ensure we have all the necessary 
-information to effectively respond to your bug report or contribution. 
- 
- 
-## Reporting Bugs/Feature Requests 
- 
-We welcome you to use the GitHub issue tracker to report bugs or suggest features. 
- 
-When filing an issue, please check [existing open](https://github.com/aws-solutions/network-orchestration-for-aws-transit-gateway/issues), or [recently closed](https://github.com/aws-solutions/network-orchestration-for-aws-transit-gateway/issues?q=is%3Aissue+is%3Aclosed), issues to make sure somebody else hasn't already 
-reported the issue. Please try to include as much information as you can. Details like these are incredibly useful: 
- 
-* A reproducible test case or series of steps 
-* The version of our code being used 
-* Any modifications you've made relevant to the bug 
-* Anything unusual about your environment or deployment 
- 
- 
-## Contributing via Pull Requests 
-Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that: 
- 
-1. You are working against the latest source on the *master* branch. 
-2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already. 
-3. You open an issue to discuss any significant work - we would hate for your time to be wasted. 
- 
-To send us a pull request, please: 
- 
-1. Fork the repository. 
-2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change. 
-3. Ensure local tests pass. 
-4. Commit to your fork using clear commit messages. 
-5. Send us a pull request, answering any default questions in the pull request interface. 
-6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation. 
- 
-GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and 
-[creating a pull request](https://help.github.com/articles/creating-a-pull-request/). 
- 
- 
-## Finding contributions to work on 
-Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels ((enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/aws-solutions/network-orchestration-for-aws-transit-gateway/labels/help%20wanted) issues is a great place to start. 
- 
- 
-## Code of Conduct 
-This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct). 
-For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact 
-opensource-codeofconduct@amazon.com with any additional questions or comments. 
- 
- 
-## Security issue notifications 
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue. 
- 
- 
-## Licensing 
-See the [LICENSE](https://github.com/aws-solutions/network-orchestration-for-aws-transit-gateway/blob/master/LICENSE.txt) file for our project's licensing. We will ask you to confirm the licensing of your contribution. 
- 
- 
-We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes. 
+# Contributing Guidelines
+
+Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional
+documentation, we greatly value feedback and contributions from our community.
+
+Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
+information to effectively respond to your bug report or contribution.
+
+## Reporting Bugs/Feature Requests
+
+We welcome you to use the GitHub issue tracker to report bugs or suggest features.
+
+When filing an issue, please check [existing open](https://github.com/aws-solutions/network-orchestration-for-aws-transit-gateway/issues), or [recently closed](https://github.com/aws-solutions/network-orchestration-for-aws-transit-gateway/issues?q=is%3Aissue+is%3Aclosed), issues to make sure somebody else hasn't already
+reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
+
+- A reproducible test case or series of steps
+- The version of our code being used
+- Any modifications you've made relevant to the bug
+- Anything unusual about your environment or deployment
+
+## Contributing via Pull Requests
+
+Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
+
+1. You are working against the latest source on the _master_ branch.
+2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
+3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
+
+To send us a pull request, please:
+
+1. Fork the repository.
+2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
+3. Ensure local tests pass.
+4. Commit to your fork using clear commit messages.
+5. Send us a pull request, answering any default questions in the pull request interface.
+6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+
+GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
+[creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
+
+## Finding contributions to work on
+
+Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels ((enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/aws-solutions/network-orchestration-for-aws-transit-gateway/labels/help%20wanted) issues is a great place to start.
+
+## Code of Conduct
+
+This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
+For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
+opensource-codeofconduct@amazon.com with any additional questions or comments.
+
+## Security issue notifications
+
+If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
+
+## Licensing
+
+See the [LICENSE](https://github.com/aws-solutions/network-orchestration-for-aws-transit-gateway/blob/master/LICENSE.txt) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+
+We may ask you to sign a [Contributor License Agreement (CLA)](https://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -9,160 +9,1562 @@ specific language governing permissions and limitations under the License.
 **********************
 THIRD PARTY COMPONENTS
 **********************
+
 This software includes third party software subject to the following copyrights:
 
-npm packages:
-@aws-amplify/api under  Apache-2.0
-@aws-amplify/auth under Apache-2.0
-@aws-amplify/core under Apache-2.0
-@aws-sdk/client-cognito-identity-provider  Apache-2.0
-@cloudscape-design/collection-hooks under Apache-2.0
-@cloudscape-design/components under Apache-2.0
-@cloudscape-design/design-tokens under Apache-2.0
-@cloudscape-design/global-styles under Apache-2.0
-@cloudscape-design/theming-runtime under Apache-2.0
-@types/node under MIT
-@types/react under MIT
-@types/react-dom under MIT
-bootstrap under MIT
-date-fns under MIT
-react under MIT
-react-dom under MIT
-react-router-dom under MIT
-react-scripts under MIT
-typescript under Apache-2.0
-web-vitals under Apache-2.0
-@babel/core under MIT
-@babel/parser under MIT
-@babel/preset-env under MIT
-@babel/preset-react under MIT
-@babel/preset-typescript under MIT
-@babel/plugin-proposal-private-property-in-object under MIT
-@testing-library/jest-dom under MIT
-@testing-library/react under MIT
-@testing-library/user-event under MIT
-@types/jest under MIT
-mnth under MIT
-webpack-dev-middleware under MIT
-nanoid under MIT
-minimist under MIT
-babel-jest under MIT
-msw under MIT
-renamer under MIT
-@aws-solutions-constructs/aws-cloudfront-s3 under Apache-2.0
-@types/jest under MIT
-@types/node under MIT
-@types/sinon under MIT
-aws-cdk under Apache-2.0
-jest under MIT
-sinon under BSD-3-Clause
-ts-jest under MIT
-ts-node under MIT
-typescript under Apache-2.0
+@aws-amplify/auth under the Apache-2.0 license.
+@aws-amplify/core under the Apache-2.0 license.
+@jest/environment under the MIT license.
+@jest/types under the MIT license.
+ansi-styles under the MIT license.
+chalk under the MIT license.
+color-convert under the MIT license.
+color-name under the MIT license.
+has-flag under the MIT license.
+supports-color under the MIT license.
+@jest/schemas under the MIT license.
+@sinclair/typebox under the MIT license.
+@types/istanbul-lib-coverage under the MIT license.
+@types/istanbul-reports under the MIT license.
+@types/istanbul-lib-report under the MIT license.
+@types/node under the MIT license.
+undici-types under the MIT license.
+@types/yargs under the MIT license.
+@types/yargs-parser under the MIT license.
+@jest/fake-timers under the MIT license.
+jest-message-util under the MIT license.
+pretty-format under the MIT license.
+react-is under the MIT license.
+@babel/code-frame under the MIT license.
+@babel/helper-validator-identifier under the MIT license.
+js-tokens under the MIT license.
+picocolors under the ISC license.
+@types/stack-utils under the MIT license.
+graceful-fs under the ISC license.
+micromatch under the MIT license.
+braces under the MIT license.
+fill-range under the MIT license.
+to-regex-range under the MIT license.
+is-number under the MIT license.
+picomatch under the MIT license.
+slash under the MIT license.
+stack-utils under the MIT license.
+escape-string-regexp under the MIT license.
+jest-util under the MIT license.
+ci-info under the MIT license.
+@react-native/virtualized-lists under the MIT license.
+invariant under the MIT license.
+loose-envify under the MIT license.
+nullthrows under the MIT license.
+@sinonjs/commons under the BSD-3-Clause license.
+type-detect under the MIT license.
+@sinonjs/fake-timers under the BSD-3-Clause license.
+@types/react under the MIT license.
+csstype under the MIT license.
+commander under the MIT license.
+jest-environment-node under the MIT license.
+jest-mock under the MIT license.
+react under the MIT license.
+react-native under the MIT license.
+@jest/create-cache-key-function under the MIT license.
+@react-native/assets-registry under the MIT license.
+@react-native/codegen under the MIT license.
+@babel/preset-env under the MIT license.
+@babel/plugin-proposal-private-property-in-object under the MIT license.
+@babel/core under the MIT license.
+@ampproject/remapping under the Apache-2.0 license.
+@jridgewell/gen-mapping under the MIT license.
+@jridgewell/set-array under the MIT license.
+@jridgewell/sourcemap-codec under the MIT license.
+@jridgewell/trace-mapping under the MIT license.
+@jridgewell/resolve-uri under the MIT license.
+@babel/generator under the MIT license.
+@babel/parser under the MIT license.
+@babel/types under the MIT license.
+@babel/helper-string-parser under the MIT license.
+jsesc under the MIT license.
+@babel/helper-compilation-targets under the MIT license.
+@babel/compat-data under the MIT license.
+@babel/helper-validator-option under the MIT license.
+browserslist under the MIT license.
+caniuse-lite under the CC-BY-4.0 license.
+electron-to-chromium under the ISC license.
+node-releases under the MIT license.
+update-browserslist-db under the MIT license.
+escalade under the MIT license.
+lru-cache under the ISC license.
+yallist under the ISC license.
+semver under the ISC license.
+@babel/helper-module-transforms under the MIT license.
+@babel/helper-module-imports under the MIT license.
+@babel/traverse under the MIT license.
+@babel/template under the MIT license.
+debug under the MIT license.
+ms under the MIT license.
+globals under the MIT license.
+@babel/helper-simple-access under the MIT license.
+@babel/helpers under the MIT license.
+convert-source-map under the MIT license.
+gensync under the MIT license.
+json5 under the MIT license.
+@babel/helper-plugin-utils under the MIT license.
+@babel/plugin-bugfix-firefox-class-in-computed-class-key under the MIT license.
+@babel/plugin-bugfix-safari-class-field-initializer-scope under the MIT license.
+@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression under the MIT license.
+@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining under the MIT license.
+@babel/helper-skip-transparent-expression-wrappers under the MIT license.
+@babel/plugin-transform-optional-chaining under the MIT license.
+@babel/plugin-syntax-optional-chaining under the MIT license.
+@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly under the MIT license.
+@babel/plugin-syntax-async-generators under the MIT license.
+@babel/plugin-syntax-class-properties under the MIT license.
+@babel/plugin-syntax-class-static-block under the MIT license.
+@babel/plugin-syntax-dynamic-import under the MIT license.
+@babel/plugin-syntax-export-namespace-from under the MIT license.
+@babel/plugin-syntax-import-assertions under the MIT license.
+@babel/plugin-syntax-import-attributes under the MIT license.
+@babel/plugin-syntax-import-meta under the MIT license.
+@babel/plugin-syntax-json-strings under the MIT license.
+@babel/plugin-syntax-logical-assignment-operators under the MIT license.
+@babel/plugin-syntax-nullish-coalescing-operator under the MIT license.
+@babel/plugin-syntax-numeric-separator under the MIT license.
+@babel/plugin-syntax-object-rest-spread under the MIT license.
+@babel/plugin-syntax-optional-catch-binding under the MIT license.
+@babel/plugin-syntax-private-property-in-object under the MIT license.
+@babel/plugin-syntax-top-level-await under the MIT license.
+@babel/plugin-syntax-unicode-sets-regex under the MIT license.
+@babel/helper-create-regexp-features-plugin under the MIT license.
+@babel/helper-annotate-as-pure under the MIT license.
+regexpu-core under the MIT license.
+@babel/regjsgen under the MIT license.
+regenerate under the MIT license.
+regenerate-unicode-properties under the MIT license.
+regjsparser under the BSD-2-Clause license.
+unicode-match-property-ecmascript under the MIT license.
+unicode-canonical-property-names-ecmascript under the MIT license.
+unicode-property-aliases-ecmascript under the MIT license.
+unicode-match-property-value-ecmascript under the MIT license.
+@babel/plugin-transform-arrow-functions under the MIT license.
+@babel/plugin-transform-async-generator-functions under the MIT license.
+@babel/helper-remap-async-to-generator under the MIT license.
+@babel/helper-wrap-function under the MIT license.
+@babel/plugin-transform-async-to-generator under the MIT license.
+@babel/plugin-transform-block-scoped-functions under the MIT license.
+@babel/plugin-transform-block-scoping under the MIT license.
+@babel/plugin-transform-class-properties under the MIT license.
+@babel/helper-create-class-features-plugin under the MIT license.
+@babel/helper-member-expression-to-functions under the MIT license.
+@babel/helper-optimise-call-expression under the MIT license.
+@babel/helper-replace-supers under the MIT license.
+@babel/plugin-transform-class-static-block under the MIT license.
+@babel/plugin-transform-classes under the MIT license.
+@babel/plugin-transform-computed-properties under the MIT license.
+@babel/plugin-transform-destructuring under the MIT license.
+@babel/plugin-transform-dotall-regex under the MIT license.
+@babel/plugin-transform-duplicate-keys under the MIT license.
+@babel/plugin-transform-duplicate-named-capturing-groups-regex under the MIT license.
+@babel/plugin-transform-dynamic-import under the MIT license.
+@babel/plugin-transform-exponentiation-operator under the MIT license.
+@babel/helper-builder-binary-assignment-operator-visitor under the MIT license.
+@babel/plugin-transform-export-namespace-from under the MIT license.
+@babel/plugin-transform-for-of under the MIT license.
+@babel/plugin-transform-function-name under the MIT license.
+@babel/plugin-transform-json-strings under the MIT license.
+@babel/plugin-transform-literals under the MIT license.
+@babel/plugin-transform-logical-assignment-operators under the MIT license.
+@babel/plugin-transform-member-expression-literals under the MIT license.
+@babel/plugin-transform-modules-amd under the MIT license.
+@babel/plugin-transform-modules-commonjs under the MIT license.
+@babel/plugin-transform-modules-systemjs under the MIT license.
+@babel/plugin-transform-modules-umd under the MIT license.
+@babel/plugin-transform-named-capturing-groups-regex under the MIT license.
+@babel/plugin-transform-new-target under the MIT license.
+@babel/plugin-transform-nullish-coalescing-operator under the MIT license.
+@babel/plugin-transform-numeric-separator under the MIT license.
+@babel/plugin-transform-object-rest-spread under the MIT license.
+@babel/plugin-transform-parameters under the MIT license.
+@babel/plugin-transform-object-super under the MIT license.
+@babel/plugin-transform-optional-catch-binding under the MIT license.
+@babel/plugin-transform-private-methods under the MIT license.
+@babel/plugin-transform-private-property-in-object under the MIT license.
+@babel/plugin-transform-property-literals under the MIT license.
+@babel/plugin-transform-regenerator under the MIT license.
+regenerator-transform under the MIT license.
+@babel/runtime under the MIT license.
+regenerator-runtime under the MIT license.
+@babel/plugin-transform-reserved-words under the MIT license.
+@babel/plugin-transform-shorthand-properties under the MIT license.
+@babel/plugin-transform-spread under the MIT license.
+@babel/plugin-transform-sticky-regex under the MIT license.
+@babel/plugin-transform-template-literals under the MIT license.
+@babel/plugin-transform-typeof-symbol under the MIT license.
+@babel/plugin-transform-unicode-escapes under the MIT license.
+@babel/plugin-transform-unicode-property-regex under the MIT license.
+@babel/plugin-transform-unicode-regex under the MIT license.
+@babel/plugin-transform-unicode-sets-regex under the MIT license.
+@babel/preset-modules under the MIT license.
+esutils under the BSD-2-Clause license.
+babel-plugin-polyfill-corejs2 under the MIT license.
+@babel/helper-define-polyfill-provider under the MIT license.
+lodash.debounce under the MIT license.
+resolve under the MIT license.
+is-core-module under the MIT license.
+hasown under the MIT license.
+function-bind under the MIT license.
+path-parse under the MIT license.
+supports-preserve-symlinks-flag under the MIT license.
+babel-plugin-polyfill-corejs3 under the MIT license.
+core-js-compat under the MIT license.
+babel-plugin-polyfill-regenerator under the MIT license.
+glob under the ISC license.
+fs.realpath under the ISC license.
+inflight under the ISC license.
+once under the ISC license.
+wrappy under the ISC license.
+inherits under the ISC license.
+minimatch under the ISC license.
+brace-expansion under the MIT license.
+balanced-match under the MIT license.
+concat-map under the MIT license.
+path-is-absolute under the MIT license.
+hermes-parser under the MIT license.
+hermes-estree under the MIT license.
+jscodeshift under the MIT license.
+signal-exit under the ISC license.
+tmp under the MIT license.
+write-file-atomic under the ISC license.
+imurmurhash under the MIT license.
+@babel/preset-flow under the MIT license.
+@babel/plugin-transform-flow-strip-types under the MIT license.
+@babel/plugin-syntax-flow under the MIT license.
+@babel/preset-typescript under the MIT license.
+@babel/plugin-syntax-jsx under the MIT license.
+@babel/plugin-transform-typescript under the MIT license.
+@babel/plugin-syntax-typescript under the MIT license.
+@babel/register under the MIT license.
+find-cache-dir under the MIT license.
+commondir under the MIT license.
+find-up under the MIT license.
+locate-path under the MIT license.
+make-dir under the MIT license.
+p-locate under the MIT license.
+p-limit under the MIT license.
+p-try under the MIT license.
+path-exists under the MIT license.
+pify under the MIT license.
+pkg-dir under the MIT license.
+clone-deep under the MIT license.
+is-plain-object under the MIT license.
+isobject under the MIT license.
+kind-of under the MIT license.
+shallow-clone under the MIT license.
+pirates under the MIT license.
+source-map-support under the MIT license.
+source-map under the BSD-3-Clause license.
+buffer-from under the MIT license.
+flow-parser under the MIT license.
+neo-async under the MIT license.
+recast under the MIT license.
+tslib under the 0BSD license.
+ast-types under the MIT license.
+esprima under the BSD-2-Clause license.
+tiny-invariant under the MIT license.
+yargs under the MIT license.
+cliui under the ISC license.
+wrap-ansi under the MIT license.
+string-width under the MIT license.
+emoji-regex under the MIT license.
+is-fullwidth-code-point under the MIT license.
+strip-ansi under the MIT license.
+ansi-regex under the MIT license.
+get-caller-file under the ISC license.
+require-directory under the MIT license.
+y18n under the ISC license.
+yargs-parser under the ISC license.
+@react-native/community-cli-plugin under the MIT license.
+@react-native/dev-middleware under the MIT license.
+open under the MIT license.
+is-docker under the MIT license.
+is-wsl under the MIT license.
+ws under the MIT license.
+async-limiter under the MIT license.
+@isaacs/ttlcache under the ISC license.
+@react-native/debugger-frontend under the BSD-3-Clause license.
+chrome-launcher under the Apache-2.0 license.
+lighthouse-logger under the Apache-2.0 license.
+marky under the Apache-2.0 license.
+chromium-edge-launcher under the Apache-2.0 license.
+mkdirp under the MIT license.
+rimraf under the ISC license.
+connect under the MIT license.
+finalhandler under the MIT license.
+encodeurl under the MIT license.
+escape-html under the MIT license.
+parseurl under the MIT license.
+unpipe under the MIT license.
+on-finished under the MIT license.
+ee-first under the MIT license.
+statuses under the MIT license.
+utils-merge under the MIT license.
+selfsigned under the MIT license.
+@types/node-forge under the MIT license.
+node-forge under the BSD-3-Clause license.
+serve-static under the MIT license.
+send under the MIT license.
+depd under the MIT license.
+destroy under the MIT license.
+etag under the MIT license.
+fresh under the MIT license.
+http-errors under the MIT license.
+setprototypeof under the ISC license.
+toidentifier under the MIT license.
+mime under the MIT license.
+range-parser under the MIT license.
+@react-native/metro-babel-transformer under the MIT license.
+@react-native/babel-preset under the MIT license.
+react-refresh under the MIT license.
+@babel/plugin-proposal-export-default-from under the MIT license.
+@babel/plugin-syntax-export-default-from under the MIT license.
+@babel/plugin-transform-react-display-name under the MIT license.
+@babel/plugin-transform-react-jsx under the MIT license.
+@babel/plugin-transform-react-jsx-self under the MIT license.
+@babel/plugin-transform-react-jsx-source under the MIT license.
+@babel/plugin-transform-runtime under the MIT license.
+@react-native/babel-plugin-codegen under the MIT license.
+babel-plugin-syntax-hermes-parser under the MIT license.
+babel-plugin-transform-flow-enums under the MIT license.
+metro under the MIT license.
+throat under the MIT license.
+accepts under the MIT license.
+mime-types under the MIT license.
+mime-db under the MIT license.
+negotiator under the MIT license.
+error-stack-parser under the MIT license.
+stackframe under the MIT license.
+flow-enums-runtime under the MIT license.
+image-size under the MIT license.
+queue under the MIT license.
+jest-worker under the MIT license.
+merge-stream under the MIT license.
+jsc-safe-url under the 0BSD license.
+lodash.throttle under the MIT license.
+metro-babel-transformer under the MIT license.
+metro-cache under the MIT license.
+exponential-backoff under the Apache-2.0 license.
+metro-core under the MIT license.
+metro-resolver under the MIT license.
+metro-cache-key under the MIT license.
+metro-config under the MIT license.
+camelcase under the MIT license.
+cosmiconfig under the MIT license.
+is-directory under the MIT license.
+js-yaml under the MIT license.
+argparse under the Python-2.0 license.
+sprintf-js under the BSD-3-Clause license.
+import-fresh under the MIT license.
+caller-path under the MIT license.
+caller-callsite under the MIT license.
+callsites under the MIT license.
+jest-validate under the MIT license.
+jest-get-type under the MIT license.
+leven under the MIT license.
+parse-json under the MIT license.
+error-ex under the MIT license.
+is-arrayish under the MIT license.
+json-parse-better-errors under the MIT license.
+resolve-from under the MIT license.
+metro-runtime under the MIT license.
+metro-file-map under the MIT license.
+fb-watchman under the Apache-2.0 license.
+bser under the Apache-2.0 license.
+node-int64 under the MIT license.
+walker under the Apache-2.0 license.
+makeerror under the BSD-3-Clause license.
+tmpl under the BSD-3-Clause license.
+metro-source-map under the MIT license.
+metro-symbolicate under the MIT license.
+vlq under the MIT license.
+ob1 under the MIT license.
+metro-transform-plugins under the MIT license.
+metro-transform-worker under the MIT license.
+metro-minify-terser under the MIT license.
+terser under the BSD-2-Clause license.
+@jridgewell/source-map under the MIT license.
+acorn under the MIT license.
+serialize-error under the MIT license.
+readline under the BSD license(s).
+@react-native/gradle-plugin under the MIT license.
+@react-native/js-polyfills under the MIT license.
+@react-native/normalize-colors under the MIT license.
+abort-controller under the MIT license.
+event-target-shim under the MIT license.
+anser under the MIT license.
+babel-jest under the MIT license.
+@jest/transform under the MIT license.
+babel-plugin-istanbul under the BSD-3-Clause license.
+@istanbuljs/load-nyc-config under the ISC license.
+get-package-type under the MIT license.
+@istanbuljs/schema under the MIT license.
+istanbul-lib-instrument under the BSD-3-Clause license.
+istanbul-lib-coverage under the BSD-3-Clause license.
+test-exclude under the ISC license.
+fast-json-stable-stringify under the MIT license.
+jest-haste-map under the MIT license.
+@types/graceful-fs under the MIT license.
+anymatch under the ISC license.
+normalize-path under the MIT license.
+jest-regex-util under the MIT license.
+fsevents under the MIT license.
+@types/babel__core under the MIT license.
+@types/babel__generator under the MIT license.
+@types/babel__template under the MIT license.
+@types/babel__traverse under the MIT license.
+babel-preset-jest under the MIT license.
+babel-plugin-jest-hoist under the MIT license.
+babel-preset-current-node-syntax under the MIT license.
+@babel/plugin-syntax-bigint under the MIT license.
+base64-js under the MIT license.
+memoize-one under the MIT license.
+promise under the MIT license.
+asap under the MIT license.
+react-devtools-core under the MIT license.
+shell-quote under the MIT license.
+stacktrace-parser under the MIT license.
+type-fest under the MIT license.
+whatwg-fetch under the MIT license.
+react-native-url-polyfill under the MIT license.
+whatwg-url-without-unicode under the MIT license.
+buffer under the MIT license.
+ieee754 under the BSD-3-Clause license.
+webidl-conversions under the BSD-2-Clause license.
+punycode under the MIT license.
+scheduler under the MIT license.
+@aws-crypto/sha256-js under the Apache-2.0 license.
+@aws-crypto/util under the Apache-2.0 license.
+@aws-sdk/types under the Apache-2.0 license.
+@aws-sdk/util-utf8-browser under the Apache-2.0 license.
+@aws-sdk/client-cloudwatch-logs under the Apache-2.0 license.
+@aws-crypto/sha256-browser under the Apache-2.0 license.
+@aws-crypto/ie11-detection under the Apache-2.0 license.
+@aws-crypto/supports-web-crypto under the Apache-2.0 license.
+@aws-sdk/util-locate-window under the Apache-2.0 license.
+@aws-sdk/config-resolver under the Apache-2.0 license.
+@aws-sdk/signature-v4 under the Apache-2.0 license.
+@aws-sdk/is-array-buffer under the Apache-2.0 license.
+@aws-sdk/util-hex-encoding under the Apache-2.0 license.
+@aws-sdk/util-uri-escape under the Apache-2.0 license.
+@aws-sdk/credential-provider-node under the Apache-2.0 license.
+@aws-sdk/credential-provider-env under the Apache-2.0 license.
+@aws-sdk/property-provider under the Apache-2.0 license.
+@aws-sdk/credential-provider-imds under the Apache-2.0 license.
+@aws-sdk/credential-provider-ini under the Apache-2.0 license.
+@aws-sdk/shared-ini-file-loader under the Apache-2.0 license.
+@aws-sdk/credential-provider-process under the Apache-2.0 license.
+@aws-sdk/fetch-http-handler under the Apache-2.0 license.
+@aws-sdk/protocol-http under the Apache-2.0 license.
+@aws-sdk/querystring-builder under the Apache-2.0 license.
+@aws-sdk/util-base64-browser under the Apache-2.0 license.
+@aws-sdk/hash-node under the Apache-2.0 license.
+@aws-sdk/util-buffer-from under the Apache-2.0 license.
+@aws-sdk/invalid-dependency under the Apache-2.0 license.
+@aws-sdk/middleware-content-length under the Apache-2.0 license.
+@aws-sdk/middleware-host-header under the Apache-2.0 license.
+@aws-sdk/middleware-logger under the Apache-2.0 license.
+@aws-sdk/middleware-retry under the Apache-2.0 license.
+react-native-get-random-values under the MIT license.
+fast-base64-decode under the MIT license.
+@aws-sdk/service-error-classification under the Apache-2.0 license.
+uuid under the MIT license.
+@aws-sdk/middleware-serde under the Apache-2.0 license.
+@aws-sdk/middleware-signing under the Apache-2.0 license.
+@aws-sdk/middleware-stack under the Apache-2.0 license.
+@aws-sdk/middleware-user-agent under the Apache-2.0 license.
+@aws-sdk/node-config-provider under the Apache-2.0 license.
+@aws-sdk/node-http-handler under the Apache-2.0 license.
+@aws-sdk/abort-controller under the Apache-2.0 license.
+@aws-sdk/smithy-client under the Apache-2.0 license.
+@aws-sdk/url-parser under the Apache-2.0 license.
+@aws-sdk/querystring-parser under the Apache-2.0 license.
+@aws-sdk/url-parser-native under the Apache-2.0 license.
+url under the MIT license.
+querystring under the MIT license.
+@aws-sdk/util-base64-node under the Apache-2.0 license.
+@aws-sdk/util-body-length-browser under the Apache-2.0 license.
+@aws-sdk/util-body-length-node under the Apache-2.0 license.
+@aws-sdk/util-user-agent-browser under the Apache-2.0 license.
+bowser under the MIT license.
+@aws-sdk/util-user-agent-node under the Apache-2.0 license.
+@aws-sdk/util-utf8-node under the Apache-2.0 license.
+@types/node-fetch under the MIT license.
+form-data under the MIT license.
+asynckit under the MIT license.
+combined-stream under the MIT license.
+delayed-stream under the MIT license.
+isomorphic-unfetch under the MIT license.
+node-fetch under the MIT license.
+whatwg-url under the MIT license.
+tr46 under the MIT license.
+unfetch under the MIT license.
+universal-cookie under the MIT license.
+@types/cookie under the MIT license.
+cookie under the MIT license.
+zen-observable-ts under the MIT license.
+zen-observable under the MIT license.
+amazon-cognito-identity-js under the Apache-2.0 license.
+isarray under the MIT license.
+js-cookie under the MIT license.
+@cloudscape-design/collection-hooks under the Apache-2.0 license.
+@cloudscape-design/components under the Apache-2.0 license.
+react-virtual under the MIT license.
+@reach/observe-rect under the MIT license.
+react-dom under the MIT license.
+@cloudscape-design/test-utils-core under the Apache-2.0 license.
+css-selector-tokenizer under the MIT license.
+cssesc under the MIT license.
+fastparse under the MIT license.
+css.escape under the MIT license.
+@cloudscape-design/theming-runtime under the Apache-2.0 license.
+@juggle/resize-observer under the Apache-2.0 license.
+ace-builds under the BSD-3-Clause license.
+clsx under the MIT license.
+d3-shape under the BSD-3-Clause license.
+d3-path under the BSD-3-Clause license.
+date-fns under the MIT license.
+mnth under the MIT license.
+react-focus-lock under the MIT license.
+focus-lock under the MIT license.
+prop-types under the MIT license.
+object-assign under the MIT license.
+react-clientside-effect under the MIT license.
+use-callback-ref under the MIT license.
+@types/prop-types under the MIT license.
+use-sidecar under the MIT license.
+detect-node-es under the MIT license.
+react-keyed-flatten-children under the MIT license.
+react-transition-group under the BSD-3-Clause license.
+dom-helpers under the MIT license.
+weekstart under the MIT license.
+@cloudscape-design/design-tokens under the Apache-2.0 license.
+@cloudscape-design/global-styles under the Apache-2.0 license.
+@types/react-dom under the MIT license.
+aws-amplify under the Apache-2.0 license.
+@aws-amplify/analytics under the Apache-2.0 license.
+@aws-amplify/cache under the Apache-2.0 license.
+@aws-sdk/client-firehose under the Apache-2.0 license.
+@aws-sdk/client-kinesis under the Apache-2.0 license.
+@aws-sdk/eventstream-serde-browser under the Apache-2.0 license.
+@aws-sdk/eventstream-marshaller under the Apache-2.0 license.
+@aws-crypto/crc32 under the Apache-2.0 license.
+@aws-sdk/eventstream-serde-universal under the Apache-2.0 license.
+@aws-sdk/eventstream-serde-config-resolver under the Apache-2.0 license.
+@aws-sdk/eventstream-serde-node under the Apache-2.0 license.
+@aws-sdk/util-waiter under the Apache-2.0 license.
+@aws-sdk/client-personalize-events under the Apache-2.0 license.
+lodash under the MIT license.
+@aws-amplify/api under the Apache-2.0 license.
+@aws-amplify/api-graphql under the Apache-2.0 license.
+@aws-amplify/api-rest under the Apache-2.0 license.
+axios under the MIT license.
+es-set-tostringtag under the MIT license.
+es-errors under the MIT license.
+get-intrinsic under the MIT license.
+call-bind-apply-helpers under the MIT license.
+es-define-property under the MIT license.
+es-object-atoms under the MIT license.
+get-proto under the MIT license.
+dunder-proto under the MIT license.
+gopd under the MIT license.
+has-symbols under the MIT license.
+math-intrinsics under the MIT license.
+has-tostringtag under the MIT license.
+follow-redirects under the MIT license.
+proxy-from-env under the MIT license.
+@aws-amplify/pubsub under the Apache-2.0 license.
+graphql under the MIT license.
+@aws-amplify/datastore under the Apache-2.0 license.
+idb under the ISC license.
+immer under the MIT license.
+ulid under the MIT license.
+zen-push under the MIT license.
+@aws-amplify/geo under the Apache-2.0 license.
+@aws-sdk/client-location under the Apache-2.0 license.
+@aws-sdk/util-config-provider under the Apache-2.0 license.
+@aws-sdk/util-middleware under the Apache-2.0 license.
+@aws-sdk/credential-provider-sso under the Apache-2.0 license.
+@aws-sdk/client-sso under the Apache-2.0 license.
+@aws-sdk/middleware-recursion-detection under the Apache-2.0 license.
+@aws-sdk/util-defaults-mode-browser under the Apache-2.0 license.
+@aws-sdk/util-defaults-mode-node under the Apache-2.0 license.
+@aws-sdk/credential-provider-web-identity under the Apache-2.0 license.
+@aws-sdk/client-sts under the Apache-2.0 license.
+@aws-sdk/middleware-sdk-sts under the Apache-2.0 license.
+entities under the BSD-2-Clause license.
+fast-xml-parser under the MIT license.
+strnum under the MIT license.
+@turf/boolean-clockwise under the MIT license.
+@turf/helpers under the MIT license.
+@turf/invariant under the MIT license.
+camelcase-keys under the MIT license.
+map-obj under the MIT license.
+quick-lru under the MIT license.
+@aws-amplify/interactions under the Apache-2.0 license.
+@aws-sdk/client-lex-runtime-service under the Apache-2.0 license.
+@aws-sdk/client-lex-runtime-v2 under the Apache-2.0 license.
+@aws-sdk/eventstream-codec under the Apache-2.0 license.
+@smithy/types under the Apache-2.0 license.
+@aws-sdk/eventstream-handler-node under the Apache-2.0 license.
+@aws-sdk/middleware-eventstream under the Apache-2.0 license.
+base-64 under the MIT license.
+fflate under the MIT license.
+pako under the (MIT AND Zlib) licenses.
+@aws-amplify/notifications under the Apache-2.0 license.
+@aws-amplify/rtn-push-notification under the Apache-2.0 license.
+@aws-amplify/predictions under the Apache-2.0 license.
+@aws-amplify/storage under the Apache-2.0 license.
+@aws-sdk/md5-js under the Apache-2.0 license.
+events under the MIT license.
+@aws-sdk/client-comprehend under the Apache-2.0 license.
+@aws-sdk/client-polly under the Apache-2.0 license.
+@aws-sdk/client-rekognition under the Apache-2.0 license.
+@aws-sdk/client-textract under the Apache-2.0 license.
+@aws-sdk/client-translate under the Apache-2.0 license.
+react-router-dom under the MIT license.
+@remix-run/router under the MIT license.
+react-router under the MIT license.
+react-scripts under the MIT license.
+jest-serializer under the MIT license.
+is-typedarray under the MIT license.
+typedarray-to-buffer under the MIT license.
+@pmmmwh/react-refresh-webpack-plugin under the MIT license.
+webpack under the MIT license.
+eslint-scope under the BSD-2-Clause license.
+esrecurse under the BSD-2-Clause license.
+estraverse under the BSD-2-Clause license.
+schema-utils under the MIT license.
+@types/json-schema under the MIT license.
+ajv under the MIT license.
+fast-deep-equal under the MIT license.
+json-schema-traverse under the MIT license.
+uri-js under the BSD-2-Clause license.
+ajv-keywords under the MIT license.
+@types/estree under the MIT license.
+@webassemblyjs/ast under the MIT license.
+@webassemblyjs/helper-numbers under the MIT license.
+@webassemblyjs/floating-point-hex-parser under the MIT license.
+@webassemblyjs/helper-api-error under the MIT license.
+@xtuc/long under the Apache-2.0 license.
+@webassemblyjs/helper-wasm-bytecode under the MIT license.
+@webassemblyjs/wasm-edit under the MIT license.
+@webassemblyjs/helper-buffer under the MIT license.
+@webassemblyjs/helper-wasm-section under the MIT license.
+@webassemblyjs/wasm-gen under the MIT license.
+@webassemblyjs/ieee754 under the MIT license.
+@xtuc/ieee754 under the BSD-3-Clause license.
+@webassemblyjs/leb128 under the Apache-2.0 license.
+@webassemblyjs/utf8 under the MIT license.
+@webassemblyjs/wasm-opt under the MIT license.
+@webassemblyjs/wasm-parser under the MIT license.
+@webassemblyjs/wast-printer under the MIT license.
+acorn-import-attributes under the MIT license.
+chrome-trace-event under the MIT license.
+enhanced-resolve under the MIT license.
+tapable under the MIT license.
+es-module-lexer under the MIT license.
+glob-to-regexp under the BSD-2-Clause license.
+json-parse-even-better-errors under the MIT license.
+loader-runner under the MIT license.
+terser-webpack-plugin under the MIT license.
+serialize-javascript under the BSD-3-Clause license.
+randombytes under the MIT license.
+safe-buffer under the MIT license.
+watchpack under the MIT license.
+webpack-sources under the MIT license.
+webpack-dev-server under the MIT license.
+webpack-dev-middleware under the MIT license.
+colorette under the MIT license.
+memfs under the Apache-2.0 license.
+fs-monkey under the Unlicense license.
+fast-uri under the MIT license.
+require-from-string under the MIT license.
+ajv-formats under the MIT license.
+@types/bonjour under the MIT license.
+@types/connect-history-api-fallback under the MIT license.
+@types/express-serve-static-core under the MIT license.
+@types/qs under the MIT license.
+@types/range-parser under the MIT license.
+@types/send under the MIT license.
+@types/mime under the MIT license.
+@types/express under the MIT license.
+@types/body-parser under the MIT license.
+@types/connect under the MIT license.
+@types/serve-static under the MIT license.
+@types/http-errors under the MIT license.
+@types/serve-index under the MIT license.
+@types/sockjs under the MIT license.
+@types/ws under the MIT license.
+ansi-html-community under the Apache-2.0 license.
+bonjour-service under the MIT license.
+multicast-dns under the MIT license.
+dns-packet under the MIT license.
+@leichtgewicht/ip-codec under the MIT license.
+thunky under the MIT license.
+chokidar under the MIT license.
+glob-parent under the ISC license.
+is-glob under the MIT license.
+is-extglob under the MIT license.
+is-binary-path under the MIT license.
+binary-extensions under the MIT license.
+readdirp under the MIT license.
+compression under the MIT license.
+bytes under the MIT license.
+compressible under the MIT license.
+on-headers under the MIT license.
+vary under the MIT license.
+connect-history-api-fallback under the MIT license.
+default-gateway under the BSD-2-Clause license.
+execa under the MIT license.
+cross-spawn under the MIT license.
+path-key under the MIT license.
+shebang-command under the MIT license.
+shebang-regex under the MIT license.
+which under the ISC license.
+isexe under the ISC license.
+get-stream under the MIT license.
+human-signals under the Apache-2.0 license.
+is-stream under the MIT license.
+npm-run-path under the MIT license.
+onetime under the MIT license.
+mimic-fn under the MIT license.
+strip-final-newline under the MIT license.
+express under the MIT license.
+path-to-regexp under the MIT license.
+array-flatten under the MIT license.
+body-parser under the MIT license.
+content-type under the MIT license.
+iconv-lite under the MIT license.
+safer-buffer under the MIT license.
+qs under the BSD-3-Clause license.
+side-channel under the MIT license.
+call-bind under the MIT license.
+set-function-length under the MIT license.
+define-data-property under the MIT license.
+has-property-descriptors under the MIT license.
+object-inspect under the MIT license.
+raw-body under the MIT license.
+type-is under the MIT license.
+media-typer under the MIT license.
+content-disposition under the MIT license.
+cookie-signature under the MIT license.
+merge-descriptors under the MIT license.
+methods under the MIT license.
+proxy-addr under the MIT license.
+ipaddr.js under the MIT license.
+forwarded under the MIT license.
+html-entities under the MIT license.
+http-proxy-middleware under the MIT license.
+@types/http-proxy under the MIT license.
+http-proxy under the MIT license.
+eventemitter3 under the MIT license.
+requires-port under the MIT license.
+is-plain-obj under the MIT license.
+launch-editor under the MIT license.
+define-lazy-prop under the MIT license.
+p-retry under the MIT license.
+@types/retry under the MIT license.
+retry under the MIT license.
+serve-index under the MIT license.
+batch under the MIT license.
+sockjs under the MIT license.
+faye-websocket under the Apache-2.0 license.
+websocket-driver under the Apache-2.0 license.
+http-parser-js under the MIT license.
+websocket-extensions under the Apache-2.0 license.
+spdy under the MIT license.
+handle-thing under the MIT license.
+http-deceiver under the MIT license.
+select-hose under the MIT license.
+spdy-transport under the MIT license.
+detect-node under the MIT license.
+hpack.js under the MIT license.
+readable-stream under the MIT license.
+core-util-is under the MIT license.
+process-nextick-args under the MIT license.
+util-deprecate under the MIT license.
+string_decoder under the MIT license.
+obuf under the MIT license.
+wbuf under the MIT license.
+minimalistic-assert under the ISC license.
+ansi-html under the Apache-2.0 license.
+core-js-pure under the MIT license.
+loader-utils under the MIT license.
+big.js under the MIT license.
+emojis-list under the MIT license.
+@svgr/webpack under the MIT license.
+@babel/plugin-transform-react-constant-elements under the MIT license.
+@babel/preset-react under the MIT license.
+@babel/plugin-transform-react-jsx-development under the MIT license.
+@babel/plugin-transform-react-pure-annotations under the MIT license.
+@svgr/core under the MIT license.
+@svgr/plugin-jsx under the MIT license.
+@svgr/babel-preset under the MIT license.
+@svgr/babel-plugin-add-jsx-attribute under the MIT license.
+@svgr/babel-plugin-remove-jsx-attribute under the MIT license.
+@svgr/babel-plugin-remove-jsx-empty-expression under the MIT license.
+@svgr/babel-plugin-replace-jsx-attribute-value under the MIT license.
+@svgr/babel-plugin-svg-dynamic-title under the MIT license.
+@svgr/babel-plugin-svg-em-dimensions under the MIT license.
+@svgr/babel-plugin-transform-react-native-svg under the MIT license.
+@svgr/babel-plugin-transform-svg-component under the MIT license.
+@svgr/hast-util-to-babel-ast under the MIT license.
+svg-parser under the MIT license.
+@types/parse-json under the MIT license.
+parent-module under the MIT license.
+lines-and-columns under the MIT license.
+path-type under the MIT license.
+yaml under the ISC license.
+@svgr/plugin-svgo under the MIT license.
+deepmerge under the MIT license.
+svgo under the MIT license.
+coa under the MIT license.
+@types/q under the MIT license.
+q under the MIT license.
+css-select under the BSD-2-Clause license.
+boolbase under the ISC license.
+css-what under the BSD-2-Clause license.
+domhandler under the BSD-2-Clause license.
+domelementtype under the BSD-2-Clause license.
+domutils under the BSD-2-Clause license.
+dom-serializer under the MIT license.
+nth-check under the BSD-2-Clause license.
+css-select-base-adapter under the MIT license.
+css-tree under the MIT license.
+mdn-data under the CC0-1.0 license.
+csso under the MIT license.
+minimist under the MIT license.
+object.values under the MIT license.
+define-properties under the MIT license.
+object-keys under the MIT license.
+sax under the ISC license.
+stable under the MIT license.
+unquote under the MIT license.
+util.promisify under the MIT license.
+es-abstract under the MIT license.
+array-buffer-byte-length under the MIT license.
+is-array-buffer under the MIT license.
+arraybuffer.prototype.slice under the MIT license.
+is-shared-array-buffer under the MIT license.
+available-typed-arrays under the MIT license.
+possible-typed-array-names under the MIT license.
+data-view-buffer under the MIT license.
+is-data-view under the MIT license.
+is-typed-array under the MIT license.
+which-typed-array under the MIT license.
+for-each under the MIT license.
+is-callable under the MIT license.
+data-view-byte-length under the MIT license.
+data-view-byte-offset under the MIT license.
+es-to-primitive under the MIT license.
+is-date-object under the MIT license.
+is-symbol under the MIT license.
+function.prototype.name under the MIT license.
+functions-have-names under the MIT license.
+get-symbol-description under the MIT license.
+globalthis under the MIT license.
+has-proto under the MIT license.
+internal-slot under the MIT license.
+is-negative-zero under the MIT license.
+is-regex under the MIT license.
+is-string under the MIT license.
+is-weakref under the MIT license.
+object.assign under the MIT license.
+regexp.prototype.flags under the MIT license.
+set-function-name under the MIT license.
+safe-array-concat under the MIT license.
+safe-regex-test under the MIT license.
+string.prototype.trim under the MIT license.
+string.prototype.trimend under the MIT license.
+string.prototype.trimstart under the MIT license.
+typed-array-buffer under the MIT license.
+typed-array-byte-length under the MIT license.
+typed-array-byte-offset under the MIT license.
+typed-array-length under the MIT license.
+unbox-primitive under the MIT license.
+has-bigints under the MIT license.
+which-boxed-primitive under the MIT license.
+is-bigint under the MIT license.
+is-boolean-object under the MIT license.
+is-number-object under the MIT license.
+object.getownpropertydescriptors under the MIT license.
+array.prototype.reduce under the MIT license.
+es-array-method-boxes-properly under the MIT license.
+babel-loader under the MIT license.
+babel-plugin-named-asset-import under the MIT license.
+babel-preset-react-app under the MIT license.
+@babel/plugin-proposal-class-properties under the MIT license.
+@babel/plugin-proposal-decorators under the MIT license.
+@babel/plugin-syntax-decorators under the MIT license.
+@babel/plugin-proposal-nullish-coalescing-operator under the MIT license.
+@babel/plugin-proposal-numeric-separator under the MIT license.
+@babel/plugin-proposal-optional-chaining under the MIT license.
+@babel/plugin-proposal-private-methods under the MIT license.
+babel-plugin-macros under the MIT license.
+babel-plugin-transform-react-remove-prop-types under the MIT license.
+bfj under the MIT license.
+bluebird under the MIT license.
+check-types under the MIT license.
+hoopy under the MIT license.
+jsonpath under the MIT license.
+static-eval under the MIT license.
+escodegen under the BSD-2-Clause license.
+levn under the MIT license.
+optionator under the MIT license.
+deep-is under the MIT license.
+fast-levenshtein under the MIT license.
+word-wrap under the MIT license.
+prelude-ls under the MIT license.
+type-check under the MIT license.
+underscore under the MIT license.
+tryer under the MIT license.
+case-sensitive-paths-webpack-plugin under the MIT license.
+css-loader under the MIT license.
+icss-utils under the ISC license.
+postcss under the MIT license.
+nanoid under the MIT license.
+source-map-js under the BSD-3-Clause license.
+postcss-modules-extract-imports under the ISC license.
+postcss-modules-local-by-default under the MIT license.
+postcss-selector-parser under the MIT license.
+postcss-value-parser under the MIT license.
+postcss-modules-scope under the ISC license.
+postcss-modules-values under the ISC license.
+css-minimizer-webpack-plugin under the MIT license.
+cssnano under the MIT license.
+cssnano-preset-default under the MIT license.
+css-declaration-sorter under the ISC license.
+cssnano-utils under the MIT license.
+postcss-calc under the MIT license.
+postcss-colormin under the MIT license.
+caniuse-api under the MIT license.
+lodash.memoize under the MIT license.
+lodash.uniq under the MIT license.
+colord under the MIT license.
+postcss-convert-values under the MIT license.
+postcss-discard-comments under the MIT license.
+postcss-discard-duplicates under the MIT license.
+postcss-discard-empty under the MIT license.
+postcss-discard-overridden under the MIT license.
+postcss-merge-longhand under the MIT license.
+stylehacks under the MIT license.
+postcss-merge-rules under the MIT license.
+postcss-minify-font-values under the MIT license.
+postcss-minify-gradients under the MIT license.
+postcss-minify-params under the MIT license.
+postcss-minify-selectors under the MIT license.
+postcss-normalize-charset under the MIT license.
+postcss-normalize-display-values under the MIT license.
+postcss-normalize-positions under the MIT license.
+postcss-normalize-repeat-style under the MIT license.
+postcss-normalize-string under the MIT license.
+postcss-normalize-timing-functions under the MIT license.
+postcss-normalize-unicode under the MIT license.
+postcss-normalize-url under the MIT license.
+normalize-url under the MIT license.
+postcss-normalize-whitespace under the MIT license.
+postcss-ordered-values under the MIT license.
+postcss-reduce-initial under the MIT license.
+postcss-reduce-transforms under the MIT license.
+postcss-svgo under the MIT license.
+@trysound/sax under the ISC license.
+postcss-unique-selectors under the MIT license.
+lilconfig under the MIT license.
+dotenv under the BSD-2-Clause license.
+dotenv-expand under the BSD-2-Clause license.
+eslint under the MIT license.
+yocto-queue under the MIT license.
+@eslint-community/eslint-utils under the MIT license.
+eslint-visitor-keys under the Apache-2.0 license.
+@eslint-community/regexpp under the MIT license.
+@eslint/eslintrc under the MIT license.
+espree under the BSD-2-Clause license.
+acorn-jsx under the MIT license.
+ignore under the MIT license.
+strip-json-comments under the MIT license.
+@eslint/js under the MIT license.
+@humanwhocodes/config-array under the Apache-2.0 license.
+@humanwhocodes/object-schema under the BSD-3-Clause license.
+@humanwhocodes/module-importer under the Apache-2.0 license.
+@nodelib/fs.walk under the MIT license.
+@nodelib/fs.scandir under the MIT license.
+@nodelib/fs.stat under the MIT license.
+run-parallel under the MIT license.
+queue-microtask under the MIT license.
+fastq under the ISC license.
+reusify under the MIT license.
+@ungap/structured-clone under the ISC license.
+doctrine under the Apache-2.0 license.
+esquery under the BSD-3-Clause license.
+file-entry-cache under the MIT license.
+flat-cache under the MIT license.
+flatted under the ISC license.
+keyv under the MIT license.
+json-buffer under the MIT license.
+graphemer under the MIT license.
+is-path-inside under the MIT license.
+json-stable-stringify-without-jsonify under the MIT license.
+lodash.merge under the MIT license.
+natural-compare under the MIT license.
+text-table under the MIT license.
+eslint-config-react-app under the MIT license.
+@babel/eslint-parser under the MIT license.
+@nicolo-ribaudo/eslint-scope-5-internals under the MIT license.
+@rushstack/eslint-patch under the MIT license.
+@typescript-eslint/eslint-plugin under the MIT license.
+@typescript-eslint/parser under the BSD-2-Clause license.
+@typescript-eslint/scope-manager under the MIT license.
+@typescript-eslint/types under the MIT license.
+@typescript-eslint/visitor-keys under the MIT license.
+@typescript-eslint/typescript-estree under the BSD-2-Clause license.
+globby under the MIT license.
+array-union under the MIT license.
+dir-glob under the MIT license.
+fast-glob under the MIT license.
+merge2 under the MIT license.
+tsutils under the MIT license.
+@typescript-eslint/type-utils under the MIT license.
+@typescript-eslint/utils under the MIT license.
+@types/semver under the MIT license.
+natural-compare-lite under the MIT license.
+confusing-browser-globals under the MIT license.
+eslint-plugin-flowtype under the BSD-3-Clause license.
+string-natural-compare under the MIT license.
+eslint-plugin-import under the MIT license.
+array-includes under the MIT license.
+array.prototype.findlastindex under the MIT license.
+es-shim-unscopables under the MIT license.
+array.prototype.flat under the MIT license.
+array.prototype.flatmap under the MIT license.
+eslint-import-resolver-node under the MIT license.
+eslint-module-utils under the MIT license.
+object.fromentries under the MIT license.
+object.groupby under the MIT license.
+tsconfig-paths under the MIT license.
+strip-bom under the MIT license.
+@types/json5 under the MIT license.
+eslint-plugin-jest under the MIT license.
+@typescript-eslint/experimental-utils under the MIT license.
+eslint-plugin-jsx-a11y under the MIT license.
+aria-query under the Apache-2.0 license.
+deep-equal under the MIT license.
+es-get-iterator under the MIT license.
+is-arguments under the MIT license.
+is-map under the MIT license.
+is-set under the MIT license.
+stop-iteration-iterator under the MIT license.
+object-is under the MIT license.
+which-collection under the MIT license.
+is-weakmap under the MIT license.
+is-weakset under the MIT license.
+ast-types-flow under the MIT license.
+axe-core under the MPL-2.0 license.
+axobject-query under the Apache-2.0 license.
+damerau-levenshtein under the BSD-2-Clause license.
+es-iterator-helpers under the MIT license.
+iterator.prototype under the MIT license.
+reflect.getprototypeof under the MIT license.
+which-builtin-type under the MIT license.
+is-async-function under the MIT license.
+is-finalizationregistry under the MIT license.
+is-generator-function under the MIT license.
+jsx-ast-utils under the MIT license.
+language-tags under the MIT license.
+language-subtag-registry under the CC0-1.0 license.
+string.prototype.includes under the MIT license.
+eslint-plugin-react under the MIT license.
+array.prototype.findlast under the MIT license.
+array.prototype.tosorted under the MIT license.
+object.entries under the MIT license.
+string.prototype.matchall under the MIT license.
+string.prototype.repeat under the MIT license.
+eslint-plugin-react-hooks under the MIT license.
+eslint-plugin-testing-library under the MIT license.
+eslint-webpack-plugin under the MIT license.
+@types/eslint under the MIT license.
+file-loader under the MIT license.
+fs-extra under the MIT license.
+jsonfile under the MIT license.
+universalify under the MIT license.
+html-webpack-plugin under the MIT license.
+@types/html-minifier-terser under the MIT license.
+html-minifier-terser under the MIT license.
+camel-case under the MIT license.
+pascal-case under the MIT license.
+no-case under the MIT license.
+lower-case under the MIT license.
+clean-css under the MIT license.
+he under the MIT license.
+param-case under the MIT license.
+dot-case under the MIT license.
+relateurl under the MIT license.
+pretty-error under the MIT license.
+renderkid under the MIT license.
+dom-converter under the MIT license.
+utila under the MIT license.
+htmlparser2 under the MIT license.
+identity-obj-proxy under the MIT license.
+harmony-reflect under the Apache-2.0 license.
+@jest/core under the MIT license.
+@jest/console under the MIT license.
+@jest/reporters under the MIT license.
+@bcoe/v8-coverage under the MIT license.
+@jest/test-result under the MIT license.
+collect-v8-coverage under the MIT license.
+exit under the MIT license.
+istanbul-lib-report under the BSD-3-Clause license.
+istanbul-lib-source-maps under the BSD-3-Clause license.
+istanbul-reports under the BSD-3-Clause license.
+html-escaper under the MIT license.
+jest-resolve under the MIT license.
+jest-pnp-resolver under the MIT license.
+resolve.exports under the MIT license.
+string-length under the MIT license.
+char-regex under the MIT license.
+terminal-link under the MIT license.
+ansi-escapes under the MIT license.
+supports-hyperlinks under the MIT license.
+v8-to-istanbul under the ISC license.
+emittery under the MIT license.
+jest-changed-files under the MIT license.
+jest-config under the MIT license.
+@jest/test-sequencer under the MIT license.
+jest-runtime under the MIT license.
+@jest/globals under the MIT license.
+diff-sequences under the MIT license.
+expect under the MIT license.
+jest-diff under the MIT license.
+jest-matcher-utils under the MIT license.
+@jest/source-map under the MIT license.
+cjs-module-lexer under the MIT license.
+jest-snapshot under the MIT license.
+@types/prettier under the MIT license.
+jest-circus under the MIT license.
+co under the MIT license.
+dedent under the MIT license.
+is-generator-fn under the MIT license.
+jest-each under the MIT license.
+jest-environment-jsdom under the MIT license.
+jsdom under the MIT license.
+abab under the BSD-3-Clause license.
+acorn-globals under the MIT license.
+acorn-walk under the MIT license.
+cssom under the MIT license.
+cssstyle under the MIT license.
+data-urls under the MIT license.
+whatwg-mimetype under the MIT license.
+decimal.js under the MIT license.
+domexception under the MIT license.
+html-encoding-sniffer under the MIT license.
+whatwg-encoding under the MIT license.
+http-proxy-agent under the MIT license.
+@tootallnate/once under the MIT license.
+agent-base under the MIT license.
+https-proxy-agent under the MIT license.
+is-potential-custom-element-name under the MIT license.
+nwsapi under the MIT license.
+parse5 under the MIT license.
+saxes under the ISC license.
+xmlchars under the MIT license.
+symbol-tree under the MIT license.
+tough-cookie under the BSD-3-Clause license.
+psl under the MIT license.
+url-parse under the MIT license.
+querystringify under the MIT license.
+w3c-hr-time under the MIT license.
+browser-process-hrtime under the BSD-2-Clause license.
+w3c-xmlserializer under the MIT license.
+xml-name-validator under the Apache-2.0 license.
+jest-jasmine2 under the MIT license.
+jest-runner under the MIT license.
+jest-docblock under the MIT license.
+detect-newline under the MIT license.
+jest-leak-detector under the MIT license.
+jest-resolve-dependencies under the MIT license.
+jest-watcher under the MIT license.
+import-local under the MIT license.
+resolve-cwd under the MIT license.
+jest-cli under the MIT license.
+prompts under the MIT license.
+kleur under the MIT license.
+sisteransi under the MIT license.
+jest-watch-typeahead under the MIT license.
+mini-css-extract-plugin under the MIT license.
+postcss-flexbugs-fixes under the MIT license.
+postcss-loader under the MIT license.
+klona under the MIT license.
+postcss-normalize under the CC0-1.0 license.
+@csstools/normalize.css under the CC0-1.0 license.
+postcss-browser-comments under the CC0-1.0 license.
+sanitize.css under the CC0-1.0 license.
+postcss-preset-env under the CC0-1.0 license.
+@csstools/postcss-cascade-layers under the CC0-1.0 license.
+@csstools/selector-specificity under the CC0-1.0 license.
+@csstools/postcss-color-function under the CC0-1.0 license.
+@csstools/postcss-progressive-custom-properties under the CC0-1.0 license.
+@csstools/postcss-font-format-keywords under the CC0-1.0 license.
+@csstools/postcss-hwb-function under the CC0-1.0 license.
+@csstools/postcss-ic-unit under the CC0-1.0 license.
+@csstools/postcss-is-pseudo-class under the CC0-1.0 license.
+@csstools/postcss-nested-calc under the CC0-1.0 license.
+@csstools/postcss-normalize-display-values under the CC0-1.0 license.
+@csstools/postcss-oklab-function under the CC0-1.0 license.
+@csstools/postcss-stepped-value-functions under the CC0-1.0 license.
+@csstools/postcss-text-decoration-shorthand under the CC0-1.0 license.
+@csstools/postcss-trigonometric-functions under the CC0-1.0 license.
+@csstools/postcss-unset-value under the CC0-1.0 license.
+autoprefixer under the MIT license.
+fraction.js under the MIT license.
+normalize-range under the MIT license.
+css-blank-pseudo under the CC0-1.0 license.
+css-has-pseudo under the CC0-1.0 license.
+css-prefers-color-scheme under the CC0-1.0 license.
+cssdb under the CC0-1.0 license.
+postcss-attribute-case-insensitive under the MIT license.
+postcss-clamp under the MIT license.
+postcss-color-functional-notation under the CC0-1.0 license.
+postcss-color-hex-alpha under the MIT license.
+postcss-color-rebeccapurple under the CC0-1.0 license.
+postcss-custom-media under the MIT license.
+postcss-custom-properties under the MIT license.
+postcss-custom-selectors under the MIT license.
+postcss-dir-pseudo-class under the CC0-1.0 license.
+postcss-double-position-gradients under the CC0-1.0 license.
+postcss-env-function under the CC0-1.0 license.
+postcss-focus-visible under the CC0-1.0 license.
+postcss-focus-within under the CC0-1.0 license.
+postcss-font-variant under the MIT license.
+postcss-gap-properties under the CC0-1.0 license.
+postcss-image-set-function under the CC0-1.0 license.
+postcss-initial under the MIT license.
+postcss-lab-function under the CC0-1.0 license.
+postcss-logical under the CC0-1.0 license.
+postcss-media-minmax under the MIT license.
+postcss-nesting under the CC0-1.0 license.
+postcss-opacity-percentage under the MIT license.
+postcss-overflow-shorthand under the CC0-1.0 license.
+postcss-page-break under the MIT license.
+postcss-place under the CC0-1.0 license.
+postcss-pseudo-class-any-link under the CC0-1.0 license.
+postcss-replace-overflow-wrap under the MIT license.
+postcss-selector-not under the MIT license.
+react-app-polyfill under the MIT license.
+core-js under the MIT license.
+raf under the MIT license.
+performance-now under the MIT license.
+react-dev-utils under the MIT license.
+address under the MIT license.
+detect-port-alt under the MIT license.
+filesize under the BSD-3-Clause license.
+fork-ts-checker-webpack-plugin under the MIT license.
+at-least-node under the ISC license.
+global-modules under the MIT license.
+global-prefix under the MIT license.
+ini under the ISC license.
+gzip-size under the MIT license.
+duplexer under the MIT license.
+is-root under the MIT license.
+pkg-up under the MIT license.
+react-error-overlay under the MIT license.
+recursive-readdir under the MIT license.
+resolve-url-loader under the MIT license.
+adjust-sourcemap-loader under the MIT license.
+regex-parser under the MIT license.
+sass-loader under the MIT license.
+source-map-loader under the MIT license.
+style-loader under the MIT license.
+tailwindcss under the MIT license.
+@alloc/quick-lru under the MIT license.
+arg under the MIT license.
+didyoumean under the Apache-2.0 license.
+dlv under the MIT license.
+jiti under the MIT license.
+object-hash under the MIT license.
+postcss-import under the MIT license.
+read-cache under the MIT license.
+postcss-js under the MIT license.
+camelcase-css under the MIT license.
+postcss-load-config under the MIT license.
+postcss-nested under the MIT license.
+sucrase under the MIT license.
+foreground-child under the ISC license.
+jackspeak under the BlueOak-1.0.0 license.
+@isaacs/cliui under the ISC license.
+eastasianwidth under the MIT license.
+@pkgjs/parseargs under the MIT license.
+minipass under the ISC license.
+package-json-from-dist under the BlueOak-1.0.0 license.
+path-scurry under the BlueOak-1.0.0 license.
+mz under the MIT license.
+any-promise under the MIT license.
+thenify-all under the MIT license.
+thenify under the MIT license.
+ts-interface-checker under the Apache-2.0 license.
+webpack-manifest-plugin under the MIT license.
+source-list-map under the MIT license.
+workbox-webpack-plugin under the MIT license.
+pretty-bytes under the MIT license.
+upath under the MIT license.
+workbox-build under the MIT license.
+@apideck/better-ajv-errors under the MIT license.
+json-schema under the BSD-3-Clause license.
+jsonpointer under the MIT license.
+lodash.sortby under the MIT license.
+@rollup/plugin-babel under the MIT license.
+rollup under the MIT license.
+@rollup/pluginutils under the MIT license.
+estree-walker under the MIT license.
+@rollup/plugin-node-resolve under the MIT license.
+@types/resolve under the MIT license.
+builtin-modules under the MIT license.
+is-module under the MIT license.
+@rollup/plugin-replace under the MIT license.
+magic-string under the MIT license.
+sourcemap-codec under the MIT license.
+@surma/rollup-plugin-off-main-thread under the Apache-2.0 license.
+ejs under the Apache-2.0 license.
+jake under the Apache-2.0 license.
+async under the MIT license.
+filelist under the Apache-2.0 license.
+common-tags under the MIT license.
+rollup-plugin-terser under the MIT license.
+stringify-object under the BSD-2-Clause license.
+get-own-enumerable-property-symbols under the ISC license.
+is-obj under the MIT license.
+is-regexp under the MIT license.
+strip-comments under the MIT license.
+tempy under the MIT license.
+temp-dir under the MIT license.
+unique-string under the MIT license.
+crypto-random-string under the MIT license.
+workbox-background-sync under the MIT license.
+workbox-core under the MIT license.
+workbox-broadcast-update under the MIT license.
+workbox-cacheable-response under the MIT license.
+workbox-expiration under the MIT license.
+workbox-google-analytics under the MIT license.
+workbox-routing under the MIT license.
+workbox-strategies under the MIT license.
+workbox-navigation-preload under the MIT license.
+workbox-precaching under the MIT license.
+workbox-range-requests under the MIT license.
+workbox-recipes under the MIT license.
+workbox-streams under the MIT license.
+workbox-sw under the MIT license.
+workbox-window under the MIT license.
+@types/trusted-types under the MIT license.
+web-vitals under the Apache-2.0 license.
+@jsonjoy.com/base64 under the Apache-2.0 license.
+@jsonjoy.com/json-pack under the Apache-2.0 license.
+hyperdyperid under the MIT license.
+@jsonjoy.com/util under the Apache-2.0 license.
+thingies under the Unlicense license.
+tree-dump under the Apache-2.0 license.
+@testing-library/dom under the MIT license.
+@types/aria-query under the MIT license.
+dom-accessibility-api under the MIT license.
+lz-string under the MIT license.
+@testing-library/jest-dom under the MIT license.
+@adobe/css-tools under the MIT license.
+redent under the MIT license.
+indent-string under the MIT license.
+strip-indent under the MIT license.
+min-indent under the MIT license.
+@testing-library/react under the MIT license.
+@testing-library/user-event under the MIT license.
+@types/jest under the MIT license.
+@jest/expect-utils under the MIT license.
+msw under the MIT license.
+@mswjs/cookies under the MIT license.
+@types/set-cookie-parser under the MIT license.
+set-cookie-parser under the MIT license.
+@mswjs/interceptors under the MIT license.
+strict-event-emitter under the MIT license.
+@open-draft/until under the MIT license.
+@types/debug under the MIT license.
+@types/ms under the MIT license.
+@xmldom/xmldom under the MIT license.
+headers-polyfill under the MIT license.
+outvariant under the MIT license.
+web-encoding under the MIT license.
+util under the MIT license.
+@zxing/text-encoding under the Apache-2.0 license.
+@types/js-levenshtein under the MIT license.
+inquirer under the MIT license.
+cli-cursor under the MIT license.
+restore-cursor under the MIT license.
+cli-width under the ISC license.
+external-editor under the MIT license.
+chardet under the MIT license.
+os-tmpdir under the MIT license.
+figures under the MIT license.
+mute-stream under the ISC license.
+ora under the MIT license.
+bl under the MIT license.
+cli-spinners under the MIT license.
+is-interactive under the MIT license.
+is-unicode-supported under the MIT license.
+log-symbols under the MIT license.
+wcwidth under the MIT license.
+defaults under the MIT license.
+clone under the MIT license.
+run-async under the MIT license.
+rxjs under the Apache-2.0 license.
+through under the MIT license.
+is-node-process under the MIT license.
+js-levenshtein under the MIT license.
+@smithy/is-array-buffer under the Apache-2.0 license.
+@smithy/util-buffer-from under the Apache-2.0 license.
+@smithy/util-utf8 under the Apache-2.0 license.
+@aws-sdk/client-sso-oidc under the Apache-2.0 license.
+@aws-sdk/core under the Apache-2.0 license.
+@smithy/core under the Apache-2.0 license.
+@smithy/middleware-endpoint under the Apache-2.0 license.
+@smithy/middleware-serde under the Apache-2.0 license.
+@smithy/node-config-provider under the Apache-2.0 license.
+@smithy/property-provider under the Apache-2.0 license.
+@smithy/shared-ini-file-loader under the Apache-2.0 license.
+@smithy/url-parser under the Apache-2.0 license.
+@smithy/querystring-parser under the Apache-2.0 license.
+@smithy/util-middleware under the Apache-2.0 license.
+@smithy/middleware-retry under the Apache-2.0 license.
+@smithy/protocol-http under the Apache-2.0 license.
+@smithy/service-error-classification under the Apache-2.0 license.
+@smithy/smithy-client under the Apache-2.0 license.
+@smithy/middleware-stack under the Apache-2.0 license.
+@smithy/util-stream under the Apache-2.0 license.
+@smithy/fetch-http-handler under the Apache-2.0 license.
+@smithy/querystring-builder under the Apache-2.0 license.
+@smithy/util-uri-escape under the Apache-2.0 license.
+@smithy/util-base64 under the Apache-2.0 license.
+@smithy/node-http-handler under the Apache-2.0 license.
+@smithy/abort-controller under the Apache-2.0 license.
+@smithy/util-hex-encoding under the Apache-2.0 license.
+@smithy/util-retry under the Apache-2.0 license.
+@smithy/signature-v4 under the Apache-2.0 license.
+@aws-sdk/credential-provider-http under the Apache-2.0 license.
+@aws-sdk/util-endpoints under the Apache-2.0 license.
+@smithy/util-endpoints under the Apache-2.0 license.
+@aws-sdk/region-config-resolver under the Apache-2.0 license.
+@smithy/util-config-provider under the Apache-2.0 license.
+@smithy/config-resolver under the Apache-2.0 license.
+@smithy/hash-node under the Apache-2.0 license.
+@smithy/invalid-dependency under the Apache-2.0 license.
+@smithy/middleware-content-length under the Apache-2.0 license.
+@smithy/util-body-length-browser under the Apache-2.0 license.
+@smithy/util-body-length-node under the Apache-2.0 license.
+@smithy/util-defaults-mode-browser under the Apache-2.0 license.
+@smithy/util-defaults-mode-node under the Apache-2.0 license.
+@smithy/credential-provider-imds under the Apache-2.0 license.
+@aws-sdk/token-providers under the Apache-2.0 license.
+@colors/colors under the MIT license.
+@dabh/diagnostics under the MIT license.
+colorspace under the MIT license.
+color under the MIT license.
+color-string under the MIT license.
+simple-swizzle under the MIT license.
+text-hex under the MIT license.
+enabled under the MIT license.
+kuler under the MIT license.
+logform under the MIT license.
+@types/triple-beam under the MIT license.
+fecha under the MIT license.
+safe-stable-stringify under the MIT license.
+triple-beam under the MIT license.
+one-time under the MIT license.
+fn.name under the MIT license.
+stack-trace under the MIT license.
+winston-transport under the MIT license.
+diff under the BSD-3-Clause license.
+@cspotcode/source-map-support under the MIT license.
+@tsconfig/node10 under the MIT license.
+@tsconfig/node12 under the MIT license.
+@tsconfig/node14 under the MIT license.
+@tsconfig/node16 under the MIT license.
+create-require under the MIT license.
+make-error under the ISC license.
+v8-compile-cache-lib under the MIT license.
+yn under the MIT license.
+@jest/expect under the MIT license.
+pure-rand under the MIT license.
+create-jest under the MIT license.
+bs-logger under the MIT license.
+@aws-sdk/client-s3 under the Apache-2.0 license.
+@aws-crypto/sha1-browser under the Apache-2.0 license.
+@aws-sdk/middleware-bucket-endpoint under the Apache-2.0 license.
+@aws-sdk/util-arn-parser under the Apache-2.0 license.
+@aws-sdk/middleware-expect-continue under the Apache-2.0 license.
+@aws-sdk/middleware-flexible-checksums under the Apache-2.0 license.
+@aws-crypto/crc32c under the Apache-2.0 license.
+@aws-sdk/middleware-location-constraint under the Apache-2.0 license.
+@aws-sdk/middleware-sdk-s3 under the Apache-2.0 license.
+@aws-sdk/middleware-ssec under the Apache-2.0 license.
+@aws-sdk/signature-v4-multi-region under the Apache-2.0 license.
+@aws-sdk/xml-builder under the Apache-2.0 license.
+@smithy/eventstream-serde-browser under the Apache-2.0 license.
+@smithy/eventstream-serde-universal under the Apache-2.0 license.
+@smithy/eventstream-codec under the Apache-2.0 license.
+@smithy/eventstream-serde-config-resolver under the Apache-2.0 license.
+@smithy/eventstream-serde-node under the Apache-2.0 license.
+@smithy/hash-blob-browser under the Apache-2.0 license.
+@smithy/chunked-blob-reader under the Apache-2.0 license.
+@smithy/chunked-blob-reader-native under the Apache-2.0 license.
+@smithy/hash-stream-node under the Apache-2.0 license.
+@smithy/md5-js under the Apache-2.0 license.
+@smithy/util-waiter under the Apache-2.0 license.
+@types/sinon under the MIT license.
+sinon under the BSD-3-Clause license.
+@sinonjs/samsam under the BSD-3-Clause license.
+lodash.get under the MIT license.
+nise under the BSD-3-Clause license.
+@sinonjs/text-encoding under the Apache-2.0 license.
+just-extend under the MIT license.
+aws-lambda-powertools under the MIT license.
+typing_extensions
+aws_lambda_typing under the MIT license.
+boto3 under the Apache-2.0 license.
+botocore under the Apache-2.0 license.
+jmespath under the MIT license.
+python-dateutil under the Apache-2.0 license.
+six under the MIT license.
+boto3-stubs under the MIT license.
+moto under the Apache-2.0 license.
+pytest-mock under the MIT license.
+pytest under the MIT license.
+sure under the GNU General Public License v3 or later (GPLv3+) license(s).
+pipdeptree under the MIT license.
+coverage under the Apache-2.0 license.
+freezegun under the Apache-2.0 license.
+typescript under the Apache-2.0 license.
+jest under the MIT license.
+@aws-sdk/client-cognito-identity-provider under the Apache-2.0 license.
+winston under the MIT license.
+decode-uri-component under the MIT license.
+ts-node under the MIT license.
+ts-jest under the MIT license.
+aws-sdk-client-mock under the MIT license.
 
-pip packages:
-winston                                  MIT
-decode-uri-component                     MIT
-jest                                     MIT
-ts-jest                                  MIT
-ts-node                                  MIT
-typescript                               Apache-2.0
-aws-sdk-client-mock                      MIT
-Jinja2                                   BSD License
-MarkupSafe                               BSD License
-PTable                                   BSD License
-PyYAML                                   MIT License
-Werkzeug                                 BSD License
-astroid                                  GNU Lesser General Public License v2 (LGPLv2)
-attrs                                    MIT License
-aws-lambda-typing                        MIT License
-aws-lambda-powertools                    MIT License
-aws-sam-translator                       Apache Software License
-aws-xray-sdk                             Apache Software License
-black                                    MIT License
-boto3                                    Apache Software License
-boto3-stubs                              MIT License
-botocore                                 Apache Software License
-botocore-stubs                           MIT License
-certifi                                  Mozilla Public License 2.0 (MPL 2.0)
-cffi                                     MIT License
-cfn-lint                                 MIT License
-charset-normalizer                       MIT License
-click                                    BSD License
-coverage                                 Apache Software License
-cryptography                             Apache Software License, BSD License
-docker                                   Apache Software License
-dill                                     BSD License (BSD-3-Clause)
-ecdsa                                    MIT License
-exceptiongroup                           MIT License
-filelock                                 The Unlicense
-freezegun                                Apache Software License
-future                                   MIT License
-idna                                     BSD License
-iniconfig                                MIT License
-isort                                    MIT License
-jmespath                                 MIT License
-jschema-to-python                        MIT License
-jsondiff                                 MIT License
-mypy-boto3-cloudformation                MIT License
-mypy-boto3-dynamodb                      MIT License
-mypy-boto3-ec2                           MIT License
-mypy-boto3-lambda                        MIT License
-mypy-boto3-logs                          MIT License
-mypy-boto3-rds                           MIT License
-mypy-boto3-s3                            MIT License
-mypy-boto3-sns                           MIT License
-mypy-boto3-sqs                           MIT License
-mypy-boto3-stepfunctions                 MIT License
-mypy-boto3-sts                           MIT License
+********************
+OPEN SOURCE LICENSES
+********************
 
-jsonpatch                                BSD License
-jsonpickle                               BSD License
-jsonpointer                              BSD License
-jsonschema                               MIT License
-junit-xml                                Freely Distributable, MIT License
-lazy-object-proxy                        BSD License
-mccabe                                   MIT License
-mpmath                                   BSD License
-mock                                     BSD License
-moto                                     Apache Software License
-mypy-boto3-organizations                 MIT License
-mypy-boto3-ram                           MIT License
-mypy-extensions                          MIT License
-networkx                                 BSD License
-packaging                                Apache Software License, BSD License
-pathspec                                 Mozilla Public License 2.0 (MPL 2.0)
-pbr                                      Apache Software License
-pipdeptree                               MIT License
-platformdirs                             MIT License
-pluggy                                   MIT License
-py                                       MIT License
-pyasn1                                   BSD License
-pycparser                                BSD License
-pydantic                                 MIT License
-pylint                                   GNU General Public License v2 (GPLv2)
-pyparsing                                MIT License
-pyrsistent                               MIT License
-pytest                                   MIT License
-pytest-mock                              MIT License
-python-dateutil                          Apache Software License, BSD License
-python-jose                              MIT License
-pytz                                     MIT License
-regex                                    Apache Software License
-responses                                Apache 2.0
-rsa                                      Apache Software License
-s3transfer                               Apache Software License
-sarif-om                                 MIT License
-six                                      MIT License
-sshpubkeys                               BSD License
-sympy                                    BSD License
-sure                                     GNU General Public License v3 or later (GPLv3+)
-tomlkit                                  MIT License
-toml                                     MIT License
-tomli                                    MIT License
-types-awscrt                             MIT License
-types-s3transfer                         MIT License
-typing_extensions                        Python Software Foundation License
-websocket-client                         Apache Software License
-wrapt                                    BSD License
-xmltodict                                MIT License
+0BSD - http://landley.net/toybox/license.html
+Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0
+BSD-2-Clause - https://opensource.org/licenses/BSD-2-Clause
+BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
+BlueOak-1.0.0 - https://blueoakcouncil.org/license/1.0.0
+CC-BY-4.0 - https://creativecommons.org/licenses/by/4.0/legalcode
+CC0-1.0 - https://creativecommons.org/publicdomain/zero/1.0/legalcode
+ISC - https://www.isc.org/licenses/
+MIT - https://opensource.org/license/mit/
+MPL-2.0 - https://www.mozilla.org/MPL/2.0/
+Python-2.0 - https://opensource.org/licenses/Python-2.0
+Unlicense - https://unlicense.org/
+Zlib - http://www.zlib.net/zlib_license.html

--- a/deployment/network-orchestration-hub.template
+++ b/deployment/network-orchestration-hub.template
@@ -69,7 +69,7 @@ Parameters:
 
   MultiFactorAuthentication:
     Type: String
-    Default: OPTIONAL
+    Default: 'ON'
     AllowedValues:
       - 'ON'
       - OPTIONAL
@@ -423,6 +423,8 @@ Resources:
           Value: !Sub STNO-TGW-${AWS::Region}
         - Key: AWS Solutions
           Value: !Ref 'AWS::StackId'
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   FlatTGWRouteTable:
     Type: AWS::EC2::TransitGatewayRouteTable
@@ -441,6 +443,8 @@ Resources:
         -
           Key: !FindInMap ["SourceCode", "Variables", "ApprovalTagKey"]
           Value: !FindInMap ["SourceCode", "Variables", "ApprovalTagValue"]
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   OnPremTGWRouteTable:
     Type: AWS::EC2::TransitGatewayRouteTable
@@ -459,6 +463,8 @@ Resources:
         -
           Key: !FindInMap ["SourceCode", "Variables", "ApprovalTagKey"]
           Value: !FindInMap ["SourceCode", "Variables", "ApprovalTagValue"]
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   IsolatedTGWRouteTable:
     Type: AWS::EC2::TransitGatewayRouteTable
@@ -474,6 +480,8 @@ Resources:
         -
           Key: !FindInMap ["SourceCode", "Variables", "ApprovalTagKey"]
           Value: !FindInMap ["SourceCode", "Variables", "ApprovalTagValue"]
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   InfrastructureTGWRouteTable:
     Type: AWS::EC2::TransitGatewayRouteTable
@@ -492,6 +500,8 @@ Resources:
         -
           Key: !FindInMap ["SourceCode", "Variables", "ApprovalTagKey"]
           Value: !FindInMap ["SourceCode", "Variables", "ApprovalTagValue"]
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   TGWResourceShare:
     Type: "AWS::RAM::ResourceShare"
@@ -510,6 +520,8 @@ Resources:
       Tags:
         - Key: Network Orchestration for AWS Transit Gateway
           Value: !Ref 'AWS::StackId'
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   ConvertPrefixListIdsToPLArnList:
     Condition: ProvidedPrefixListIds
@@ -530,6 +542,8 @@ Resources:
       Tags:
         - Key: Network Orchestration for AWS Transit Gateway
           Value: !Ref 'AWS::StackId'
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   ApprovalTopic:
     Type: AWS::SNS::Topic
@@ -537,6 +551,9 @@ Resources:
       DisplayName: !FindInMap [NotificationConfiguration ,SNS ,DisplayName]
       TopicName: !FindInMap [NotificationConfiguration ,SNS ,TopicName]
       KmsMasterKeyId: alias/aws/sns
+      Tags:
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   NetworkAdminEmailNotification:
     Condition: NotificationCondition
@@ -763,6 +780,9 @@ Resources:
     Type: AWS::Events::EventBus
     Properties:
       Name: !FindInMap [EventBridge, Bus, Name]
+      Tags:
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   EventBridgeBusPermission:
     Type: Custom::CWEventPermissions
@@ -801,6 +821,9 @@ Resources:
       Role: !Sub ${CustomResourceLambdaFunctionRole.Arn}
       Runtime: python3.11
       Timeout: 900
+      Tags:
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
 
   LambdaPermissionSpokeAccount:
@@ -829,6 +852,10 @@ Resources:
 
   CustomResourceLambdaFunctionRole:
     Type: AWS::IAM::Role
+    Metadata:
+      guard:
+        SuppressedRules:
+          - IAM_NO_INLINE_POLICY_CHECK
     Properties:
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
@@ -860,6 +887,9 @@ Resources:
                   - events:RemovePermission
                   - events:PutPermission
                 Resource: !Sub ${STNOCustomEventBus.Arn}
+      Tags:
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   PolicyIAMEC2:
     Type: AWS::IAM::Policy
@@ -952,6 +982,10 @@ Resources:
 
   DynamoDbTable:
     Type: 'AWS::DynamoDB::Table'
+    Metadata:
+      guard:
+        SuppressedRules:
+          - DYNAMODB_TABLE_ENCRYPTED_KMS
     Properties:
         AttributeDefinitions:
             - AttributeName: SubnetId
@@ -972,6 +1006,9 @@ Resources:
           SSEType: KMS
         PointInTimeRecoverySpecification:
           PointInTimeRecoveryEnabled: true
+        Tags:
+          - Key: !GetAtt Application.ApplicationTagKey
+            Value: !GetAtt Application.ApplicationTagValue
 
   StateMachineLambdaFunction:
     Type: AWS::Lambda::Function
@@ -1014,6 +1051,8 @@ Resources:
           LOG_GROUP_ACTIONS: !Ref CloudWatchLogActions
           USER_AGENT_STRING: AwsSolution/SO0058/%VERSION%
           SOLUTION_UUID: !GetAtt CreateUniqueID.UUID
+          APPLICATION_TAG_KEY: !GetAtt Application.ApplicationTagKey
+          APPLICATION_TAG_VALUE: !GetAtt Application.ApplicationTagValue
       Code:
         S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],"tgw_vpc_attachment.zip"]]
@@ -1023,10 +1062,16 @@ Resources:
       Role: !GetAtt 'StateMachineLambdaFunctionRole.Arn'
       Runtime: python3.11
       Timeout: 900
+      Tags:
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   StateMachineRole:
     Type: "AWS::IAM::Role"
     Metadata:
+      guard:
+        SuppressedRules:
+          - IAM_NO_INLINE_POLICY_CHECK
       cfn_nag:
         rules_to_suppress:
           - id: W11
@@ -1064,10 +1109,16 @@ Resources:
                   - "logs:DescribeLogGroups"
                 Resource:
                   - "*"
+      Tags:
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   StateMachineLambdaFunctionRole:
     Type: AWS::IAM::Role
     Metadata:
+      guard:
+        SuppressedRules:
+          - IAM_NO_INLINE_POLICY_CHECK
       cfn_nag:
         rules_to_suppress:
           - id: W28
@@ -1112,10 +1163,16 @@ Resources:
                       - sts:AssumeRole
                     Resource: !Ref OrganizationManagementAccountRoleArn
                   - !Ref AWS::NoValue
+      Tags:
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   OrchestratorStateMachine:
     Type: 'AWS::StepFunctions::StateMachine'
     Properties:
+      Tags:
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
       StateMachineName: STNO-StateMachine
       RoleArn: !GetAtt 'StateMachineRole.Arn'
       LoggingConfiguration:
@@ -2017,6 +2074,9 @@ Resources:
   TgwPeeringLambdaFunctionRole:
     Type: AWS::IAM::Role
     Metadata:
+      guard:
+        SuppressedRules:
+          - IAM_NO_INLINE_POLICY_CHECK
       cfn_nag:
         rules_to_suppress:
           - id: W11
@@ -2060,6 +2120,9 @@ Resources:
                 Action:
                   - ec2:DescribeTransitGatewayPeeringAttachments
                 Resource: "*"
+      Tags:
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   TgwPeeringLambdaFunction:
     Type: AWS::Lambda::Function
@@ -2093,6 +2156,9 @@ Resources:
       Role: !Sub ${TgwPeeringLambdaFunctionRole.Arn}
       Runtime: python3.11
       Timeout: 900
+      Tags:
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   
   ########################################
@@ -2111,6 +2177,8 @@ Resources:
           Value: STNO-Global-Network
         - Key: AWS Serverless Transit Network Orchestrator
           Value: !Ref 'AWS::StackId'
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   GlobalNetworkRegistrationSTNO:
     Type: AWS::NetworkManager::TransitGatewayRegistration
@@ -2136,11 +2204,15 @@ Resources:
         AwsRegion:
           Ref: AWS::Region
         DefaultAction: DENY
+      IntrospectionConfig: DISABLED
       LogConfig:
         CloudWatchLogsRoleArn: !GetAtt AppSyncRole.Arn
-        ExcludeVerboseContent: False
-        FieldLogLevel: NONE
+        ExcludeVerboseContent: True
+        FieldLogLevel: INFO
       XrayEnabled: true
+      Tags:
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   STNOGraphQLApiWebACLAssociation:
     Type: AWS::WAFv2::WebACLAssociation
@@ -2321,7 +2393,7 @@ Resources:
                   (${AWS::Region})"
                   EmailMessage:
                     !Sub |
-                        <p>Here are your temporary login credentials for Serverless Transit Network Orchestrator Console: https://${ConsoleCloudFront.DomainName}</p>
+                        <p>Here are your temporary login credentials for Network Orchestration for AWS Transit Gateway Console</p>
                         <p>
                         Region: ${AWS::Region}<br />
                         Username: <strong>{username}</strong><br />
@@ -2426,6 +2498,10 @@ Resources:
   ############################
   FrontEndCognitoTriggerFunctionRole:
     Type: AWS::IAM::Role
+    Metadata:
+      guard:
+        SuppressedRules:
+          - IAM_NO_INLINE_POLICY_CHECK
     Properties:
       AssumeRolePolicyDocument:
         Statement:
@@ -2457,6 +2533,9 @@ Resources:
                   - !Sub arn:${AWS::Partition}:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/*
             Version: "2012-10-17"
           PolicyName: AddUserToReadOnlyUserGroupPolicy
+      Tags:
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
     Condition: FrontEndCognitoSAMLCondition
 
   FrontEndCognitoTriggerFunction:
@@ -2476,8 +2555,11 @@ Resources:
           SOLUTION_ID: !FindInMap [Solution, Metrics, SolutionId]
           SOLUTION_VERSION: !FindInMap [SourceCode, General, Version]
       Handler: index.handler
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x
       Timeout: 60
+      Tags:
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
     DependsOn:
       - FrontEndCognitoTriggerFunctionRole
     Metadata:
@@ -2592,6 +2674,10 @@ Resources:
    ############################
   CognitoAuthRole:
       Type: "AWS::IAM::Role"
+      Metadata:
+        guard:
+          SuppressedRules:
+            - IAM_NO_INLINE_POLICY_CHECK
       Condition: DeployWebUiCondition
       Properties:
           AssumeRolePolicyDocument:
@@ -2621,6 +2707,9 @@ Resources:
                             - "cognito-identity:GetId"
                           Resource:
                             - !Join ["",[!Sub "arn:${AWS::Partition}:cognito-identity:", !Ref "AWS::Region", ":", !Ref "AWS::AccountId", ":identitypool/", !Ref IdentityPool]]
+          Tags:
+            - Key: !GetAtt Application.ApplicationTagKey
+              Value: !GetAtt Application.ApplicationTagValue
 
   IdentityPoolRoleAttachment:
     Type: "AWS::Cognito::IdentityPoolRoleAttachment"
@@ -2640,6 +2729,9 @@ Resources:
                 ClientId: !Ref UserPoolClient
                 ProviderName: !GetAtt STNOUserPool.ProviderName
                 ServerSideTokenCheck: false
+          IdentityPoolTags:
+            - Key: !GetAtt Application.ApplicationTagKey
+              Value: !GetAtt Application.ApplicationTagValue
 
   ##########################
   # Amazon DynamoDB Role #
@@ -2647,6 +2739,10 @@ Resources:
   AppSyncRole:
     Type: AWS::IAM::Role
     Condition: DeployWebUiCondition
+    Metadata:
+      guard:
+        SuppressedRules:
+          - IAM_NO_INLINE_POLICY_CHECK
     Properties:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
@@ -2688,6 +2784,9 @@ Resources:
                 - dynamodb:Scan
                 - dynamodb:Query
                 Resource: !GetAtt DynamoDbTable.Arn
+      Tags:
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   ##########################
   # S3 Bucket #
@@ -2712,6 +2811,9 @@ Resources:
               SSEAlgorithm: AES256
       VersioningConfiguration:
         Status: Enabled
+      Tags:
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   ConsoleBucketPolicy:
     Type: 'AWS::S3::BucketPolicy'
@@ -2763,6 +2865,9 @@ Resources:
         LogFilePrefix: logsbucket_logs/
       VersioningConfiguration:
         Status: Enabled
+      Tags:
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   LogsBucketS3BucketPolicy:
     Type: AWS::S3::BucketPolicy
@@ -2776,6 +2881,16 @@ Resources:
             Principal: "*"
             Action: s3:DeleteBucket
             Resource: !Sub arn:${AWS::Partition}:s3:::${LogsBucket}
+          - Sid: DenyNonTLSRequests
+            Effect: Deny
+            Action: s3:*
+            Resource:
+              - !GetAtt LogsBucket.Arn
+              - !Join [ "/", [ !GetAtt LogsBucket.Arn, "*" ] ]
+            Condition:
+              Bool:
+                aws:SecureTransport: False
+            Principal: "*"
 
   ##########################
   # Cloud Front #
@@ -2796,6 +2911,9 @@ Resources:
       Description: CIDR ranges allowed access to STNO web UI
       IPAddressVersion: IPV4
       Addresses: !Ref AllowListedRanges
+      Tags:
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   STNOGraphQLApiWebACL:
     Type: AWS::WAFv2::WebACL
@@ -2834,6 +2952,45 @@ Resources:
               VendorName: AWS
               Name: "AWSManagedRulesCommonRuleSet"
               ExcludedRules: []
+        - Name: "AWS-AWSManagedRulesAmazonIpReputationList"
+          Priority: 2
+          OverrideAction:
+            None: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: "AWS-AWSManagedRulesAmazonIpReputationList"
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: "AWSManagedRulesAmazonIpReputationList"
+        - Name: "AWS-AWSManagedRulesAnonymousIpList"
+          Priority: 3
+          OverrideAction:
+            None: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: "AWS-AWSManagedRulesAnonymousIpList"
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: "AWSManagedRulesAnonymousIpList"
+        - Name: "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+          Priority: 4
+          OverrideAction:
+            None: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: "AWSManagedRulesKnownBadInputsRuleSet"
+      Tags:
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   SecurityHeaderFunction:
     Type: AWS::CloudFront::Function
@@ -2887,18 +3044,10 @@ Resources:
                   AllowedMethods:
                       - GET
                       - HEAD
-                      - OPTIONS
-                      - PUT
-                      - POST
-                      - PATCH
-                      - DELETE
-                  CachedMethods:
-                      - GET
-                      - HEAD
-                      - OPTIONS
                   ForwardedValues:
                       QueryString: false
                   ViewerProtocolPolicy: redirect-to-https
+                  ResponseHeadersPolicyId: !GetAtt CloudFrontResponseHeadersPolicy.Id
               IPV6Enabled: true
               DefaultRootObject: "index.html"
               CustomErrorResponses:
@@ -2916,6 +3065,26 @@ Resources:
                 Bucket: !Join ['',[!Ref LogsBucket,'.s3.amazonaws.com']]
                 IncludeCookies: false
                 Prefix: cloudfront_logs/
+          Tags:
+            - Key: !GetAtt Application.ApplicationTagKey
+              Value: !GetAtt Application.ApplicationTagValue
+
+  CloudFrontResponseHeadersPolicy:
+    Type: AWS::CloudFront::ResponseHeadersPolicy
+    Properties:
+      ResponseHeadersPolicyConfig:
+        Name: !Sub CSP-for-Network-Orchestrator-${AWS::Region}
+        Comment: "Security headers for CSP"
+        SecurityHeadersConfig:
+          ContentSecurityPolicy:
+            ContentSecurityPolicy: !Sub
+              - "upgrade-insecure-requests; object-src 'none'; frame-ancestors 'none'; base-uri 'none'; script-src 'self'; style-src 'self'; \
+              default-src 'self' https://${UserPoolDomain}.auth.${AWSRegion}.amazoncognito.com https://cognito-identity.${AWSRegion}.amazonaws.com \
+              https://cognito-idp.${AWSRegion}.amazonaws.com ${GraphQLEndpoint};"
+              - UserPoolDomain: !Ref UserPoolDomain
+                GraphQLEndpoint: !GetAtt AppSyncPipelineApi.GraphQLUrl
+                AWSRegion: !Ref AWS::Region
+            Override: false
 
   ConsoleIAMPolicy:
     Type: "AWS::IAM::Policy"
@@ -2975,6 +3144,9 @@ Resources:
   CloudWatchLogFailures:
     Type: AWS::Logs::LogGroup
     Metadata:
+      guard:
+        SuppressedRules:
+          - CW_LOGGROUP_RETENTION_PERIOD_CHECK
       cfn_nag:
           rules_to_suppress:
               - id: W84
@@ -2982,10 +3154,16 @@ Resources:
     Properties:
       RetentionInDays: !FindInMap ["LogRetention", "CloudWatchLogs", "RetentionPeriod"]
       LogGroupName: STNO-Hub-Failures
+      Tags:
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   CloudWatchLogActions:
     Type: AWS::Logs::LogGroup
     Metadata:
+      guard:
+        SuppressedRules:
+          - CW_LOGGROUP_RETENTION_PERIOD_CHECK
       cfn_nag:
           rules_to_suppress:
               - id: W84
@@ -2993,10 +3171,16 @@ Resources:
     Properties:
       RetentionInDays: !FindInMap ["LogRetention", "CloudWatchLogs", "RetentionPeriod"]
       LogGroupName: STNO-Hub-Actions
+      Tags:
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   CloudWatchLogStateMachine:
     Type: AWS::Logs::LogGroup
     Metadata:
+      guard:
+        SuppressedRules:
+          - CW_LOGGROUP_RETENTION_PERIOD_CHECK
       cfn_nag:
         rules_to_suppress:
           - id: W84
@@ -3004,6 +3188,9 @@ Resources:
     Properties:
       RetentionInDays: !FindInMap [ "LogRetention", "CloudWatchLogs", "RetentionPeriod" ]
       LogGroupName: STNO-StateMachine
+      Tags:
+        - Key: !GetAtt Application.ApplicationTagKey
+          Value: !GetAtt Application.ApplicationTagValue
 
   # AppRegistry Application
   Application:
@@ -3024,38 +3211,6 @@ Resources:
         'Solutions:SolutionVersion': "%VERSION%",
         'Solutions:ApplicationType': 'AWS-Solutions'
       }
-
-  AppRegistryApplicationStackAssociation:
-    Type: AWS::ServiceCatalogAppRegistry::ResourceAssociation
-    Condition: DeployIfNotChinaPartition
-    Properties:
-      Application: !GetAtt Application.Id
-      Resource:
-        !Ref AWS::StackId
-      ResourceType: CFN_STACK
-
-  DefaultApplicationAttributeGroup:
-    Type: AWS::ServiceCatalogAppRegistry::AttributeGroup
-    Condition: DeployIfNotChinaPartition
-    Properties:
-      Name: !Sub 'AttrGrp-${AWS::Region}-${AWS::StackName}'
-      Description: Network Orchestration for AWS Transit Gateway.
-      Attributes:
-        { "ApplicationType": "AWS Solution",
-          "Author": "CloudFoundations",
-          "Team": "CloudFoundations",
-          "Version": "%VERSION%",
-          "SolutionID": !FindInMap [ Solution, Metrics, SolutionId ],
-          "SolutionName": !FindInMap [ Solution, Data, SolutionName ],
-        }
-      Tags: { 'CloudFoundations:NetworkOrchestrationForAWSTransitGateway': !Ref "AWS::StackName" }
-
-  AppRegistryApplicationAttributeAssociation:
-    Type: AWS::ServiceCatalogAppRegistry::AttributeGroupAssociation
-    Condition: DeployIfNotChinaPartition
-    Properties:
-      Application: !GetAtt Application.Id
-      AttributeGroup: !GetAtt DefaultApplicationAttributeGroup.Id
 
 ##########################
   # Outputs #
@@ -3120,5 +3275,5 @@ Outputs:
     Value: !Ref DynamoDbTable
   AppSyncAPI:
     Description: The AppSync API
-    Value: !Ref AppSyncPipelineApi
+    Value: !GetAtt AppSyncPipelineApi.GraphQLUrl
     Condition: DeployWebUiCondition

--- a/deployment/network-orchestration-organization-role.template
+++ b/deployment/network-orchestration-organization-role.template
@@ -19,6 +19,9 @@ Resources:
   OrganizationInformationRole:
     Type: AWS::IAM::Role
     Metadata:
+      guard:
+        SuppressedRules:
+          - IAM_NO_INLINE_POLICY_CHECK
       cfn_nag:
         rules_to_suppress:
           - id: W11

--- a/deployment/network-orchestration-spoke.template
+++ b/deployment/network-orchestration-spoke.template
@@ -125,6 +125,9 @@ Resources:
   TransitNetworkExecutionRole:
     Type: AWS::IAM::Role
     Metadata:
+      guard:
+        SuppressedRules:
+          - IAM_NO_INLINE_POLICY_CHECK
       cfn_nag:
         rules_to_suppress:
           - id: W28
@@ -197,6 +200,10 @@ Resources:
   # This role is only needed if the spoke account belongs to an AWS Organization
   TransitNetworkEventDeliveryRole:
     Type: AWS::IAM::Role
+    Metadata:
+      guard:
+        SuppressedRules:
+          - IAM_NO_INLINE_POLICY_CHECK
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -248,6 +255,10 @@ Resources:
 
   CustomResourceLambdaFunctionRole:
     Type: AWS::IAM::Role
+    Metadata:
+      guard:
+        SuppressedRules:
+          - IAM_NO_INLINE_POLICY_CHECK
     Properties:
       AssumeRolePolicyDocument:
         Version: '2012-10-17'

--- a/source/cognito-trigger/package-lock.json
+++ b/source/cognito-trigger/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cognito-trigger",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cognito-trigger",
-      "version": "3.3.14",
+      "version": "3.3.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.102.0",

--- a/source/cognito-trigger/package.json
+++ b/source/cognito-trigger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cognito-trigger",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "Triggered when a new user is confirmed in the user pool to allow for custom actions to be taken",
   "author": {
     "name": "Amazon Web Services",

--- a/source/lambda/pyproject.toml
+++ b/source/lambda/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "network-orchestration-for-tgw"
-version = "3.3.13"
+version = "3.3.15"
 description = "solution packages for network-orchestration-for-tgw"
 requires-python = ">=3.10"
 license = { text = "Apache Software License" }

--- a/source/lambda/tgw_vpc_attachment/__tests__/test_ec2.py
+++ b/source/lambda/tgw_vpc_attachment/__tests__/test_ec2.py
@@ -26,3 +26,38 @@ def test_create_tags_batch_success(mocker):
     client_stubber.activate()
     ec2.create_tags_batch(resource_id, tags_list)
     spy_logger.assert_called_with(log_message)
+
+def test_create_tgw_attachment_with_app_registry_tags():
+    #  Arrange
+    ec2 = EC2()
+    ec2_client_stub = Stubber(ec2.ec2_client)
+
+    tgw_id = "my_tgw"
+    vpc_id = "my_vpc_id"
+    subnet_id = "my_subnet"
+    os.environ["APPLICATION_TAG_KEY"] = "awsApplication"
+    os.environ["APPLICATION_TAG_VALUE"] = "myApp"
+    expected_params = {
+        "SubnetIds": [subnet_id],
+        "TransitGatewayId": tgw_id,
+        "VpcId": vpc_id,
+        "TagSpecifications": [
+            {
+                "ResourceType": "transit-gateway-attachment",
+                "Tags": [
+                    {
+                        "Key": os.getenv("APPLICATION_TAG_KEY"),
+                        "Value": os.getenv("APPLICATION_TAG_VALUE")
+                    }
+                ]
+            }
+        ]
+    }
+
+    ec2_client_stub.add_response("create_transit_gateway_vpc_attachment", {}, expected_params)
+    ec2_client_stub.activate()
+
+    # Act/Assert
+    with ec2_client_stub:
+        ec2.create_transit_gateway_vpc_attachment(tgw_id, vpc_id, subnet_id)
+        ec2_client_stub.assert_no_pending_responses()

--- a/source/lambda/tgw_vpc_attachment/lib/clients/ec2.py
+++ b/source/lambda/tgw_vpc_attachment/lib/clients/ec2.py
@@ -208,9 +208,24 @@ class EC2:
             vpc_id: str,
             subnet_id: str
     ) -> CreateTransitGatewayVpcAttachmentResultTypeDef:
+        tag_specifications = []
+        # get tag key and value from environment variables
+        tgw_attachment_tag_key = os.environ.get('APPLICATION_TAG_KEY')
+        tgw_attachment_tag_value = os.environ.get('APPLICATION_TAG_VALUE')
+        if  tgw_attachment_tag_key is not None and tgw_attachment_tag_value is not None:
+            tag_specifications = [{
+                'ResourceType': 'transit-gateway-attachment', # reference https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TagSpecification.html
+                'Tags': [
+                    {
+                        'Key': tgw_attachment_tag_key,
+                        'Value': tgw_attachment_tag_value
+                    }
+                ]
+            }]
         response: CreateTransitGatewayVpcAttachmentResultTypeDef = \
             self.ec2_client.create_transit_gateway_vpc_attachment(
-                TransitGatewayId=tgw_id, VpcId=vpc_id, SubnetIds=[subnet_id]
+                TransitGatewayId=tgw_id, VpcId=vpc_id, SubnetIds=[subnet_id],
+                TagSpecifications=tag_specifications # AppRegistry application tags
             )
         self.logger.debug(response)
         return response

--- a/source/ui/package-lock.json
+++ b/source/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "network-orchestrator-for-aws-transit-gateway",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "network-orchestrator-for-aws-transit-gateway",
-      "version": "3.3.14",
+      "version": "3.3.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/auth": "^5.4.0",
@@ -71,12 +71,12 @@
       }
     },
     "node_modules/@aws-amplify/analytics": {
-      "version": "6.5.12",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-6.5.12.tgz",
-      "integrity": "sha512-8z3mXLzUoMkR47W9UrK/yNw7Qo98HuhYaPW9gQa0/H5mC4IIiN/ka0RurefKTx89xkPUxIuv7pAIWqMcg8NMCA==",
+      "version": "6.5.14",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-6.5.14.tgz",
+      "integrity": "sha512-sAv7X8t3WL+t+0z+zAahIXhx/f5rrstCy1RlMEykxP5FWEwKKTpDBO9LdWZLGNnR1nYeTUeKwSl2zzn2FdYS0w==",
       "dependencies": {
-        "@aws-amplify/cache": "5.1.18",
-        "@aws-amplify/core": "5.8.12",
+        "@aws-amplify/cache": "5.1.20",
+        "@aws-amplify/core": "5.8.14",
         "@aws-sdk/client-firehose": "3.6.1",
         "@aws-sdk/client-kinesis": "3.6.1",
         "@aws-sdk/client-personalize-events": "3.6.1",
@@ -86,34 +86,26 @@
         "uuid": "^3.2.1"
       }
     },
-    "node_modules/@aws-amplify/analytics/node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
-      "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
-      "dependencies": {
-        "tslib": "^1.8.0"
-      }
-    },
     "node_modules/@aws-amplify/api": {
-      "version": "5.4.12",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-5.4.12.tgz",
-      "integrity": "sha512-LHxfHpwu6hFm6sMiPB6UAKzj5Aoccp/r4527dTg6N/aQwQXyWEGkGSK4dBSSM/Sf0vPADo9jn6WGNttCXulDyw==",
+      "version": "5.4.16",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-5.4.16.tgz",
+      "integrity": "sha512-j4yTG0cOK0YvBNItamY2Nhugn5mP3WJEDyhUZSGY16k1h4GWzG0k247GMqAJpDwDp6e5KvQZKt92i+c1+ZW+dg==",
       "dependencies": {
-        "@aws-amplify/api-graphql": "3.4.18",
-        "@aws-amplify/api-rest": "3.5.12",
+        "@aws-amplify/api-graphql": "3.4.22",
+        "@aws-amplify/api-rest": "3.5.14",
         "tslib": "^1.8.0"
       }
     },
     "node_modules/@aws-amplify/api-graphql": {
-      "version": "3.4.18",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-3.4.18.tgz",
-      "integrity": "sha512-4rZ0vhfTQnP+kCL+uc0BZdHsjNU1vLj5+xOPIkNrI0Y0VdN9I2aKfWjBQx8i2BIPeF3B+xSKKuGhIJD6WCxcpg==",
+      "version": "3.4.22",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-3.4.22.tgz",
+      "integrity": "sha512-6Y8G+RfAZWy4tjTf8iC/c8YEDT15GvpLNep7NGhKAsemQ35CDg/AtktlFKbk5MrRP9+gd/qlU0hWBgTa1pQOGw==",
       "dependencies": {
-        "@aws-amplify/api-rest": "3.5.12",
-        "@aws-amplify/auth": "5.6.12",
-        "@aws-amplify/cache": "5.1.18",
-        "@aws-amplify/core": "5.8.12",
-        "@aws-amplify/pubsub": "5.5.12",
+        "@aws-amplify/api-rest": "3.5.14",
+        "@aws-amplify/auth": "5.6.15",
+        "@aws-amplify/cache": "5.1.20",
+        "@aws-amplify/core": "5.8.14",
+        "@aws-amplify/pubsub": "5.6.2",
         "graphql": "15.8.0",
         "tslib": "^1.8.0",
         "uuid": "^3.2.1",
@@ -121,41 +113,41 @@
       }
     },
     "node_modules/@aws-amplify/api-rest": {
-      "version": "3.5.12",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-3.5.12.tgz",
-      "integrity": "sha512-WWUZU7MaKxxt9xw+FwnSWfbsXEwoDbGH6G8/S0YrcQeILbutLLcW4boW3d2vRaYjjC/1saVUHyrdO1mWZ++C5Q==",
+      "version": "3.5.14",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-3.5.14.tgz",
+      "integrity": "sha512-+vqdckBs4+T/J1+uTbg8Lxd8toH1n0ttV8K89LQ7t9aaGntomLEQJlfBLtZyII8lM3oJyKB26J0Eh9z15IaH7Q==",
       "dependencies": {
-        "@aws-amplify/core": "5.8.12",
+        "@aws-amplify/core": "5.8.14",
         "axios": "^1.6.5",
         "tslib": "^1.8.0",
         "url": "0.11.0"
       }
     },
     "node_modules/@aws-amplify/auth": {
-      "version": "5.6.12",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-5.6.12.tgz",
-      "integrity": "sha512-NX5E2l9Ovsbfsh2R0iNweNVVY3QtJRWpBrHPIOxzhqSxiwK0Cay/+9bQ8Uv7/O8s2NHByG1+kXM7zR+iDuYxfA==",
+      "version": "5.6.15",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-5.6.15.tgz",
+      "integrity": "sha512-bMaP09rd/tIZvDAbhhVEEBdpoEgnt1ua5S6efQzfY6zpwdDLEgP+ZJ8hJLCjgPx5SpZ9G0+ltg0Ig5tBWAo2vA==",
       "dependencies": {
-        "@aws-amplify/core": "5.8.12",
-        "amazon-cognito-identity-js": "6.3.13",
+        "@aws-amplify/core": "5.8.14",
+        "amazon-cognito-identity-js": "6.3.14",
         "buffer": "4.9.2",
         "tslib": "^1.8.0",
         "url": "0.11.0"
       }
     },
     "node_modules/@aws-amplify/cache": {
-      "version": "5.1.18",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-5.1.18.tgz",
-      "integrity": "sha512-1aZ8MvA+8PJur5cnJAbBUnCUCw3ACfjCI/s/qY+Fx1jKahci3J9Yl2+pf4A6Nk6e0IjtN6FVCOKUKcWV/5+QYQ==",
+      "version": "5.1.20",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-5.1.20.tgz",
+      "integrity": "sha512-3mnfVm/u2ndio3j/0yywbKT3HpAuS2RJeuTlwqXpMOhZBdJJmzNMBTo5ZIkl5MlnppozQ3LD62sdT372hOwZiQ==",
       "dependencies": {
-        "@aws-amplify/core": "5.8.12",
+        "@aws-amplify/core": "5.8.14",
         "tslib": "^1.8.0"
       }
     },
     "node_modules/@aws-amplify/core": {
-      "version": "5.8.12",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.12.tgz",
-      "integrity": "sha512-kQkIRBiowtMawBPTviAkz6q9Od6IImrYxdnjFebHNqF1fuLq016jxhBLxiq5ztZDvkZX+IpSr1gzOZtNGkikvA==",
+      "version": "5.8.14",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-5.8.14.tgz",
+      "integrity": "sha512-QU+3zQspE9f2CrZOtGDuHBZU9WqZ6PDQUEslVV+VCu2CduBDTtfnl1hCfVJ6vnUIxhwB24onpBwKz/IGZgh86g==",
       "dependencies": {
         "@aws-crypto/sha256-js": "1.2.2",
         "@aws-sdk/client-cloudwatch-logs": "3.6.1",
@@ -165,7 +157,7 @@
         "isomorphic-unfetch": "^3.0.0",
         "react-native-url-polyfill": "^1.3.0",
         "tslib": "^1.8.0",
-        "universal-cookie": "^4.0.4",
+        "universal-cookie": "^7.2.2",
         "zen-observable-ts": "0.8.19"
       }
     },
@@ -202,9 +194,9 @@
       }
     },
     "node_modules/@aws-amplify/core/node_modules/@react-native/virtualized-lists": {
-      "version": "0.74.86",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.74.86.tgz",
-      "integrity": "sha512-f5wZpQvlGeWcyfK3Low0tOft9ounAaVQHpa4fiHjh9x3d2EPLwoaQe7sxS0q8/5pMISjddbF9S3ofpNuDxxoeA==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.78.0.tgz",
+      "integrity": "sha512-ibETs3AwpkkRcORRANvZeEFjzvN41W02X882sBzoxC5XdHiZ2DucXo4fjKF7i86MhYCFLfNSIYbwupx1D1iFmg==",
       "peer": true,
       "dependencies": {
         "invariant": "^2.2.4",
@@ -214,7 +206,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@types/react": "^18.2.6",
+        "@types/react": "^19.0.0",
         "react": "*",
         "react-native": "*"
       },
@@ -242,13 +234,14 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
-    "node_modules/@aws-amplify/core/node_modules/@types/yargs": {
-      "version": "15.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-      "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
+    "node_modules/@aws-amplify/core/node_modules/@types/react": {
+      "version": "19.0.11",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.11.tgz",
+      "integrity": "sha512-vrdxRZfo9ALXth6yPfV16PYTLZwsUWhVjjC+DkfE5t1suNSbBrWC9YqSuuxJZ8Ps6z1o2ycRpIqzZJIgklq4Tw==",
+      "optional": true,
       "peer": true,
       "dependencies": {
-        "@types/yargs-parser": "*"
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/@aws-amplify/core/node_modules/ansi-styles": {
@@ -300,6 +293,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "peer": true
     },
+    "node_modules/@aws-amplify/core/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@aws-amplify/core/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -341,90 +343,87 @@
       }
     },
     "node_modules/@aws-amplify/core/node_modules/pretty-format": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-      "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "peer": true,
       "dependencies": {
-        "@jest/types": "^26.6.2",
-        "ansi-regex": "^5.0.0",
-        "ansi-styles": "^4.0.0",
-        "react-is": "^17.0.1"
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
       },
       "engines": {
-        "node": ">= 10"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@aws-amplify/core/node_modules/pretty-format/node_modules/@jest/types": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-      "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+    "node_modules/@aws-amplify/core/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "peer": true,
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^15.0.0",
-        "chalk": "^4.0.0"
-      },
       "engines": {
-        "node": ">= 10.14.2"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@aws-amplify/core/node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@aws-amplify/core/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "peer": true
+    },
     "node_modules/@aws-amplify/core/node_modules/react-native": {
-      "version": "0.74.4",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.74.4.tgz",
-      "integrity": "sha512-Cox7h0UkFPY+79DsInn2BAhnmGiqKBHKoYHoPAPW8oQCPyna8jvS0hfUmHBWm/MOHSXi4NYPKd5plpD50B3B2Q==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.78.0.tgz",
+      "integrity": "sha512-3PO4tNvCN6BdAKcoY70v1sLfxYCmDR4KS1VTY+kIBKy5Qznp27QNxL7zBQjvS6Jp91gc8N82QbysQrfBlwg9gQ==",
       "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.6.3",
-        "@react-native-community/cli": "13.6.9",
-        "@react-native-community/cli-platform-android": "13.6.9",
-        "@react-native-community/cli-platform-ios": "13.6.9",
-        "@react-native/assets-registry": "0.74.86",
-        "@react-native/codegen": "0.74.86",
-        "@react-native/community-cli-plugin": "0.74.86",
-        "@react-native/gradle-plugin": "0.74.86",
-        "@react-native/js-polyfills": "0.74.86",
-        "@react-native/normalize-colors": "0.74.86",
-        "@react-native/virtualized-lists": "0.74.86",
+        "@react-native/assets-registry": "0.78.0",
+        "@react-native/codegen": "0.78.0",
+        "@react-native/community-cli-plugin": "0.78.0",
+        "@react-native/gradle-plugin": "0.78.0",
+        "@react-native/js-polyfills": "0.78.0",
+        "@react-native/normalize-colors": "0.78.0",
+        "@react-native/virtualized-lists": "0.78.0",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
+        "babel-jest": "^29.7.0",
+        "babel-plugin-syntax-hermes-parser": "0.25.1",
         "base64-js": "^1.5.1",
         "chalk": "^4.0.0",
+        "commander": "^12.0.0",
         "event-target-shim": "^5.0.1",
         "flow-enums-runtime": "^0.0.6",
+        "glob": "^7.1.1",
         "invariant": "^2.2.4",
         "jest-environment-node": "^29.6.3",
-        "jsc-android": "^250231.0.0",
         "memoize-one": "^5.0.0",
-        "metro-runtime": "^0.80.3",
-        "metro-source-map": "^0.80.3",
-        "mkdirp": "^0.5.1",
+        "metro-runtime": "^0.81.0",
+        "metro-source-map": "^0.81.0",
         "nullthrows": "^1.1.1",
-        "pretty-format": "^26.5.2",
+        "pretty-format": "^29.7.0",
         "promise": "^8.3.0",
-        "react-devtools-core": "^5.0.0",
+        "react-devtools-core": "^6.0.1",
         "react-refresh": "^0.14.0",
-        "react-shallow-renderer": "^16.15.0",
         "regenerator-runtime": "^0.13.2",
-        "scheduler": "0.24.0-canary-efb381bbf-20230505",
+        "scheduler": "0.25.0",
+        "semver": "^7.1.3",
         "stacktrace-parser": "^0.1.10",
         "whatwg-fetch": "^3.0.0",
-        "ws": "^6.2.2",
+        "ws": "^6.2.3",
         "yargs": "^17.6.2"
       },
       "bin": {
@@ -434,8 +433,8 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@types/react": "^18.2.6",
-        "react": "18.2.0"
+        "@types/react": "^19.0.0",
+        "react": "^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -470,12 +469,21 @@
       "peer": true
     },
     "node_modules/@aws-amplify/core/node_modules/scheduler": {
-      "version": "0.24.0-canary-efb381bbf-20230505",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.24.0-canary-efb381bbf-20230505.tgz",
-      "integrity": "sha512-ABvovCDe/k9IluqSh4/ISoq8tIJnW8euVAWYt5j/bg6dRnqwQwiGO1F/V4AyK96NGF/FB04FhOUDuWj8IKfABA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "peer": true
+    },
+    "node_modules/@aws-amplify/core/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@aws-amplify/core/node_modules/supports-color": {
@@ -500,15 +508,15 @@
       }
     },
     "node_modules/@aws-amplify/datastore": {
-      "version": "4.7.12",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-4.7.12.tgz",
-      "integrity": "sha512-BnyZZPvYAka6D4OHfid7/UCBvXgpZTvXTydBW0YFZ3mIoRiTZC9+rcWm0i3EjtjUuGJuzbLhxDqklXGvUsXCkg==",
+      "version": "4.7.16",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-4.7.16.tgz",
+      "integrity": "sha512-o+YAzARAlvtv4+iHERkyeClT84uP11HKPZ8s084TwwE03o/L1ym5dDBbhYq4vaB7meDurCNiuQLHVHosPYPlLQ==",
       "dependencies": {
-        "@aws-amplify/api": "5.4.12",
-        "@aws-amplify/auth": "5.6.12",
-        "@aws-amplify/core": "5.8.12",
-        "@aws-amplify/pubsub": "5.5.12",
-        "amazon-cognito-identity-js": "6.3.13",
+        "@aws-amplify/api": "5.4.16",
+        "@aws-amplify/auth": "5.6.15",
+        "@aws-amplify/core": "5.8.14",
+        "@aws-amplify/pubsub": "5.6.2",
+        "amazon-cognito-identity-js": "6.3.14",
         "buffer": "4.9.2",
         "idb": "5.0.6",
         "immer": "9.0.6",
@@ -519,25 +527,25 @@
       }
     },
     "node_modules/@aws-amplify/geo": {
-      "version": "2.3.12",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/geo/-/geo-2.3.12.tgz",
-      "integrity": "sha512-H8cyusFfWhXANefNJz/rYAMAmD8cNPC36xzFfXrqHJTKplEUY+3dRMvkOx2gDZpqYF8Ij9qJ5BOoPfs7Jh6ySA==",
+      "version": "2.3.14",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/geo/-/geo-2.3.14.tgz",
+      "integrity": "sha512-HKJlxu1e+yd5P7kD8tCwbMRaNJdusVPifargT7E8i0AY6FXiylYz2U8PedhcIRlgJykCIhuNoTMMA8nOVYgKHg==",
       "dependencies": {
-        "@aws-amplify/core": "5.8.12",
-        "@aws-sdk/client-location": "3.186.3",
+        "@aws-amplify/core": "5.8.14",
+        "@aws-sdk/client-location": "3.186.4",
         "@turf/boolean-clockwise": "6.5.0",
         "camelcase-keys": "6.2.2",
         "tslib": "^1.8.0"
       }
     },
     "node_modules/@aws-amplify/interactions": {
-      "version": "5.2.18",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/interactions/-/interactions-5.2.18.tgz",
-      "integrity": "sha512-K1oo6GFS7kgq86QMjmF+dabuFEeJLAu1FK1tfTyFIhvrgZ4xfVnzdTXlJhS+ZJ5ZKc6WyzVmE8di/KllI+pTAA==",
+      "version": "5.2.21",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/interactions/-/interactions-5.2.21.tgz",
+      "integrity": "sha512-RduNt/0zZOgsQa1sC/1Ro3q6m4rQ4JStdqEXWEujtkzmiRB6I1BzdxuM0bjOLvDAXqdVGy2dWRMgpmhRzg7JOg==",
       "dependencies": {
-        "@aws-amplify/core": "5.8.12",
-        "@aws-sdk/client-lex-runtime-service": "3.186.3",
-        "@aws-sdk/client-lex-runtime-v2": "3.186.3",
+        "@aws-amplify/core": "5.8.14",
+        "@aws-sdk/client-lex-runtime-service": "3.186.4",
+        "@aws-sdk/client-lex-runtime-v2": "3.186.4",
         "base-64": "1.0.0",
         "fflate": "0.7.3",
         "pako": "2.0.4",
@@ -545,24 +553,24 @@
       }
     },
     "node_modules/@aws-amplify/notifications": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-1.6.13.tgz",
-      "integrity": "sha512-fH1k8P1Nts/1OIy8IKQjWpJgdsql0562CPpwGBVvPnRYqnkPxvzImjZdhwTgpu+vxjDBKEky/Buu9ws+ST7Myg==",
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-1.6.16.tgz",
+      "integrity": "sha512-gLz26cdn0H1J4rbOJg4K6pnUARAUgfUb9OtlfoTYaHjPR8rWBphrACNEJBOWZKuRuJi3bSIVQy0EZT8sbYr4tA==",
       "dependencies": {
-        "@aws-amplify/cache": "5.1.18",
-        "@aws-amplify/core": "5.8.12",
-        "@aws-amplify/rtn-push-notification": "1.1.14",
+        "@aws-amplify/cache": "5.1.20",
+        "@aws-amplify/core": "5.8.14",
+        "@aws-amplify/rtn-push-notification": "1.1.15",
         "lodash": "^4.17.21",
         "uuid": "^3.2.1"
       }
     },
     "node_modules/@aws-amplify/predictions": {
-      "version": "5.5.12",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/predictions/-/predictions-5.5.12.tgz",
-      "integrity": "sha512-KY2YUDkhNGtRIHDYDcuNIVxAfUbLP2vH1268TXRoUaZvRz5NKTKAje8Ht5AnoCDhSWTN7nduoivL97fRzo6bJA==",
+      "version": "5.5.17",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/predictions/-/predictions-5.5.17.tgz",
+      "integrity": "sha512-8Zu/BQjK8PAD3KI44OMSadz/o9WGujipQAW2qH6LgVpOS4e7l1g2cPEw5xwSBrodJOiXJ6REyWbzujXlp1ZTDw==",
       "dependencies": {
-        "@aws-amplify/core": "5.8.12",
-        "@aws-amplify/storage": "5.9.12",
+        "@aws-amplify/core": "5.8.14",
+        "@aws-amplify/storage": "5.9.16",
         "@aws-sdk/client-comprehend": "3.6.1",
         "@aws-sdk/client-polly": "3.6.1",
         "@aws-sdk/client-rekognition": "3.6.1",
@@ -576,13 +584,13 @@
       }
     },
     "node_modules/@aws-amplify/pubsub": {
-      "version": "5.5.12",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-5.5.12.tgz",
-      "integrity": "sha512-eD57TUee9n7ECNPWFIl1TcZmQf8+usiB2vo7t6nBgjCoudYRhYh8ZPfxg94uqfDdWBXMbRoBI0JPISyEQo2xKA==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-5.6.2.tgz",
+      "integrity": "sha512-aOrBMcEO9ulsPlTy0p91OS8PU9SiFNcFoT3NKmlTYok9XR/1Yf0dgAaXCttuOYCjjlt9T+QKyJ96m3z3cIJr1Q==",
       "dependencies": {
-        "@aws-amplify/auth": "5.6.12",
-        "@aws-amplify/cache": "5.1.18",
-        "@aws-amplify/core": "5.8.12",
+        "@aws-amplify/auth": "5.6.15",
+        "@aws-amplify/cache": "5.1.20",
+        "@aws-amplify/core": "5.8.14",
         "buffer": "4.9.2",
         "graphql": "15.8.0",
         "tslib": "^1.8.0",
@@ -592,16 +600,16 @@
       }
     },
     "node_modules/@aws-amplify/rtn-push-notification": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/rtn-push-notification/-/rtn-push-notification-1.1.14.tgz",
-      "integrity": "sha512-C3y+iL8/9800wWOyIAVYAKzrHZkFeI3y2ZoJlj0xot+dCbQZkMr/XjO2ZwfC58XRKUiDKFfzCJW/XoyZlvthfw=="
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/rtn-push-notification/-/rtn-push-notification-1.1.15.tgz",
+      "integrity": "sha512-nqn+xZkO4pX107rQmVieBRLGC9Qj65PDJqutmY5BX85DIt8vsPfWqLnuZlx4Y6uvaddosgmyt441U/Rd7Kc8ig=="
     },
     "node_modules/@aws-amplify/storage": {
-      "version": "5.9.12",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-5.9.12.tgz",
-      "integrity": "sha512-aQ9JCRJL+Dlrg5mxlvZtKuBm1NjrU/8aFZ51VdHr4BWQBfAchSk9s3UcnHeh+o8pGWCl1z9W05yp12eXTWauEw==",
+      "version": "5.9.16",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-5.9.16.tgz",
+      "integrity": "sha512-Ck2h2D14Hw1HdBaJ4e/QWtknvE+Whnn8iHLndSo9Z9rCU0QK8arIYs2KogvggihRi0drT+3ykfsZfpZYco/WCg==",
       "dependencies": {
-        "@aws-amplify/core": "5.8.12",
+        "@aws-amplify/core": "5.8.14",
         "@aws-sdk/md5-js": "3.6.1",
         "@aws-sdk/types": "3.6.1",
         "buffer": "4.9.2",
@@ -631,21 +639,21 @@
       }
     },
     "node_modules/@aws-crypto/crc32/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
-      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+      "version": "3.734.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.734.0.tgz",
+      "integrity": "sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==",
       "dependencies": {
-        "@smithy/types": "^3.3.0",
+        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-crypto/crc32/node_modules/@aws-sdk/types/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-crypto/ie11-detection": {
       "version": "1.0.0",
@@ -750,23 +758,10 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
-      "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
-      "dependencies": {
-        "tslib": "^1.8.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
     "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/client-comprehend": {
       "version": "3.6.1",
@@ -810,23 +805,10 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
-      "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
-      "dependencies": {
-        "tslib": "^1.8.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-comprehend/node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
     "node_modules/@aws-sdk/client-comprehend/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/client-firehose": {
       "version": "3.6.1",
@@ -869,23 +851,10 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
-      "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
-      "dependencies": {
-        "tslib": "^1.8.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-firehose/node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
     "node_modules/@aws-sdk/client-firehose/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/client-kinesis": {
       "version": "3.6.1",
@@ -932,32 +901,19 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
-      "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
-      "dependencies": {
-        "tslib": "^1.8.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
     "node_modules/@aws-sdk/client-kinesis/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/client-lex-runtime-service": {
-      "version": "3.186.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lex-runtime-service/-/client-lex-runtime-service-3.186.3.tgz",
-      "integrity": "sha512-YP+GDY9OxyW4rJDqjreaNpiDBvH1uzO3ShJKl57hT92Kw2auDQxttcMf//J8dQXvrVkW/fVXCLI9TmtxS7XJOQ==",
+      "version": "3.186.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lex-runtime-service/-/client-lex-runtime-service-3.186.4.tgz",
+      "integrity": "sha512-ftPIjDR5gmoSu9YXQLWdtiSxGfdSlHSWi+Zqun24f3YHZuLACN514JppvHTcNBztpmtnCU4qx3eFjKg6aMOosg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.186.3",
+        "@aws-sdk/client-sts": "3.186.4",
         "@aws-sdk/config-resolver": "3.186.0",
         "@aws-sdk/credential-provider-node": "3.186.0",
         "@aws-sdk/fetch-http-handler": "3.186.0",
@@ -1598,9 +1554,9 @@
       }
     },
     "node_modules/@aws-sdk/client-lex-runtime-service/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/client-lex-runtime-service/node_modules/uuid": {
       "version": "8.3.2",
@@ -1611,13 +1567,13 @@
       }
     },
     "node_modules/@aws-sdk/client-lex-runtime-v2": {
-      "version": "3.186.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lex-runtime-v2/-/client-lex-runtime-v2-3.186.3.tgz",
-      "integrity": "sha512-4MJfSnb+qM8BYW4ToCvg7sDWN0NcEqK738hCZUV89cjp7pIHZ6osJuS/PsmZEommVj+71GviZ4buu5KUCfCGFQ==",
+      "version": "3.186.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lex-runtime-v2/-/client-lex-runtime-v2-3.186.4.tgz",
+      "integrity": "sha512-ELoZYwTIoQWVw1a+ImE1n4z8b/5DqgzXti8QSoC2VaKv8dNwDO1xWal2LJhw20HPcTkAhHL8IA3gU/tTrWXk1g==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.186.3",
+        "@aws-sdk/client-sts": "3.186.4",
         "@aws-sdk/config-resolver": "3.186.0",
         "@aws-sdk/credential-provider-node": "3.186.0",
         "@aws-sdk/eventstream-handler-node": "3.186.0",
@@ -2314,9 +2270,9 @@
       }
     },
     "node_modules/@aws-sdk/client-lex-runtime-v2/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/client-lex-runtime-v2/node_modules/uuid": {
       "version": "8.3.2",
@@ -2327,13 +2283,13 @@
       }
     },
     "node_modules/@aws-sdk/client-location": {
-      "version": "3.186.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-location/-/client-location-3.186.3.tgz",
-      "integrity": "sha512-LCMFgoWfvKBnZhhtl93RLhrsHCalM7huaxErHSKoqWDBUDP0i7rOX73qW8E25j/vQ4emEkT0d6ts1rDu4EnlNw==",
+      "version": "3.186.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-location/-/client-location-3.186.4.tgz",
+      "integrity": "sha512-wHRVFdIDZVbae2w1axi4R8idiWH3CRZy22Zrtybfs/fvrC5xZZxFaLwXQtvPJdOf0RUGgQeOTsvJl2sInKSj+w==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.186.3",
+        "@aws-sdk/client-sts": "3.186.4",
         "@aws-sdk/config-resolver": "3.186.0",
         "@aws-sdk/credential-provider-node": "3.186.0",
         "@aws-sdk/fetch-http-handler": "3.186.0",
@@ -2974,9 +2930,9 @@
       }
     },
     "node_modules/@aws-sdk/client-location/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/client-location/node_modules/uuid": {
       "version": "8.3.2",
@@ -3027,23 +2983,10 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
-      "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
-      "dependencies": {
-        "tslib": "^1.8.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-personalize-events/node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
     "node_modules/@aws-sdk/client-personalize-events/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/client-polly": {
       "version": "3.6.1",
@@ -3086,23 +3029,10 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-polly/node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
-      "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
-      "dependencies": {
-        "tslib": "^1.8.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-polly/node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
     "node_modules/@aws-sdk/client-polly/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/client-rekognition": {
       "version": "3.6.1",
@@ -3146,23 +3076,10 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-rekognition/node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
-      "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
-      "dependencies": {
-        "tslib": "^1.8.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-rekognition/node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
     "node_modules/@aws-sdk/client-rekognition/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/client-sso": {
       "version": "3.186.0",
@@ -3713,9 +3630,9 @@
       }
     },
     "node_modules/@aws-sdk/client-sso/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/client-sso/node_modules/uuid": {
       "version": "8.3.2",
@@ -3726,9 +3643,9 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.186.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.186.3.tgz",
-      "integrity": "sha512-mnttdyYBtqO+FkDtOT3F1FGi8qD11fF5/3zYLaNuFFULqKneaIwW2YIsjFlgvPGpmoyo/tNplnZwhQ9xQtT3Sw==",
+      "version": "3.186.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.186.4.tgz",
+      "integrity": "sha512-KeC7eNoasv5A/cwC3uyM7xwyFiLYA0wz8YSG2rmvWHsW7vRn/95ATyNGlzNCpTQq3rlNORJ39yxpQCY7AxTb9g==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -3764,7 +3681,7 @@
         "@aws-sdk/util-utf8-browser": "3.186.0",
         "@aws-sdk/util-utf8-node": "3.186.0",
         "entities": "2.2.0",
-        "fast-xml-parser": "4.2.5",
+        "fast-xml-parser": "4.4.1",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -4375,9 +4292,9 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/client-sts/node_modules/uuid": {
       "version": "8.3.2",
@@ -4428,23 +4345,10 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-textract/node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
-      "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
-      "dependencies": {
-        "tslib": "^1.8.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-textract/node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
     "node_modules/@aws-sdk/client-textract/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/client-translate": {
       "version": "3.6.1",
@@ -4488,23 +4392,10 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-translate/node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
-      "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
-      "dependencies": {
-        "tslib": "^1.8.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-translate/node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
     "node_modules/@aws-sdk/client-translate/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/config-resolver": {
       "version": "3.6.1",
@@ -4640,9 +4531,9 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
       "version": "3.186.0",
@@ -4678,9 +4569,9 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/eventstream-codec": {
       "version": "3.186.0",
@@ -4713,9 +4604,9 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-codec/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
       "version": "3.186.0",
@@ -4739,9 +4630,9 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/eventstream-marshaller": {
       "version": "3.6.1",
@@ -4872,14 +4763,6 @@
         "tslib": "^1.8.0"
       }
     },
-    "node_modules/@aws-sdk/md5-js/node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
-      "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
-      "dependencies": {
-        "tslib": "^1.8.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-content-length": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.6.1.tgz",
@@ -4927,9 +4810,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.6.1",
@@ -4990,9 +4873,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/middleware-retry": {
       "version": "3.6.1",
@@ -5043,9 +4926,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/@react-native/virtualized-lists": {
-      "version": "0.74.86",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.74.86.tgz",
-      "integrity": "sha512-f5wZpQvlGeWcyfK3Low0tOft9ounAaVQHpa4fiHjh9x3d2EPLwoaQe7sxS0q8/5pMISjddbF9S3ofpNuDxxoeA==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.78.0.tgz",
+      "integrity": "sha512-ibETs3AwpkkRcORRANvZeEFjzvN41W02X882sBzoxC5XdHiZ2DucXo4fjKF7i86MhYCFLfNSIYbwupx1D1iFmg==",
       "peer": true,
       "dependencies": {
         "invariant": "^2.2.4",
@@ -5055,7 +4938,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@types/react": "^18.2.6",
+        "@types/react": "^19.0.0",
         "react": "*",
         "react-native": "*"
       },
@@ -5083,13 +4966,14 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/@types/yargs": {
-      "version": "15.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-      "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
+    "node_modules/@aws-sdk/middleware-retry/node_modules/@types/react": {
+      "version": "19.0.11",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.11.tgz",
+      "integrity": "sha512-vrdxRZfo9ALXth6yPfV16PYTLZwsUWhVjjC+DkfE5t1suNSbBrWC9YqSuuxJZ8Ps6z1o2ycRpIqzZJIgklq4Tw==",
+      "optional": true,
       "peer": true,
       "dependencies": {
-        "@types/yargs-parser": "*"
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/ansi-styles": {
@@ -5141,6 +5025,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "peer": true
     },
+    "node_modules/@aws-sdk/middleware-retry/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@aws-sdk/middleware-retry/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -5182,90 +5075,87 @@
       }
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/pretty-format": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-      "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "peer": true,
       "dependencies": {
-        "@jest/types": "^26.6.2",
-        "ansi-regex": "^5.0.0",
-        "ansi-styles": "^4.0.0",
-        "react-is": "^17.0.1"
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
       },
       "engines": {
-        "node": ">= 10"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/pretty-format/node_modules/@jest/types": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-      "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+    "node_modules/@aws-sdk/middleware-retry/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "peer": true,
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^15.0.0",
-        "chalk": "^4.0.0"
-      },
       "engines": {
-        "node": ">= 10.14.2"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-retry/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "peer": true
+    },
     "node_modules/@aws-sdk/middleware-retry/node_modules/react-native": {
-      "version": "0.74.4",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.74.4.tgz",
-      "integrity": "sha512-Cox7h0UkFPY+79DsInn2BAhnmGiqKBHKoYHoPAPW8oQCPyna8jvS0hfUmHBWm/MOHSXi4NYPKd5plpD50B3B2Q==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.78.0.tgz",
+      "integrity": "sha512-3PO4tNvCN6BdAKcoY70v1sLfxYCmDR4KS1VTY+kIBKy5Qznp27QNxL7zBQjvS6Jp91gc8N82QbysQrfBlwg9gQ==",
       "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.6.3",
-        "@react-native-community/cli": "13.6.9",
-        "@react-native-community/cli-platform-android": "13.6.9",
-        "@react-native-community/cli-platform-ios": "13.6.9",
-        "@react-native/assets-registry": "0.74.86",
-        "@react-native/codegen": "0.74.86",
-        "@react-native/community-cli-plugin": "0.74.86",
-        "@react-native/gradle-plugin": "0.74.86",
-        "@react-native/js-polyfills": "0.74.86",
-        "@react-native/normalize-colors": "0.74.86",
-        "@react-native/virtualized-lists": "0.74.86",
+        "@react-native/assets-registry": "0.78.0",
+        "@react-native/codegen": "0.78.0",
+        "@react-native/community-cli-plugin": "0.78.0",
+        "@react-native/gradle-plugin": "0.78.0",
+        "@react-native/js-polyfills": "0.78.0",
+        "@react-native/normalize-colors": "0.78.0",
+        "@react-native/virtualized-lists": "0.78.0",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
+        "babel-jest": "^29.7.0",
+        "babel-plugin-syntax-hermes-parser": "0.25.1",
         "base64-js": "^1.5.1",
         "chalk": "^4.0.0",
+        "commander": "^12.0.0",
         "event-target-shim": "^5.0.1",
         "flow-enums-runtime": "^0.0.6",
+        "glob": "^7.1.1",
         "invariant": "^2.2.4",
         "jest-environment-node": "^29.6.3",
-        "jsc-android": "^250231.0.0",
         "memoize-one": "^5.0.0",
-        "metro-runtime": "^0.80.3",
-        "metro-source-map": "^0.80.3",
-        "mkdirp": "^0.5.1",
+        "metro-runtime": "^0.81.0",
+        "metro-source-map": "^0.81.0",
         "nullthrows": "^1.1.1",
-        "pretty-format": "^26.5.2",
+        "pretty-format": "^29.7.0",
         "promise": "^8.3.0",
-        "react-devtools-core": "^5.0.0",
+        "react-devtools-core": "^6.0.1",
         "react-refresh": "^0.14.0",
-        "react-shallow-renderer": "^16.15.0",
         "regenerator-runtime": "^0.13.2",
-        "scheduler": "0.24.0-canary-efb381bbf-20230505",
+        "scheduler": "0.25.0",
+        "semver": "^7.1.3",
         "stacktrace-parser": "^0.1.10",
         "whatwg-fetch": "^3.0.0",
-        "ws": "^6.2.2",
+        "ws": "^6.2.3",
         "yargs": "^17.6.2"
       },
       "bin": {
@@ -5275,8 +5165,8 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@types/react": "^18.2.6",
-        "react": "18.2.0"
+        "@types/react": "^19.0.0",
+        "react": "^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -5311,12 +5201,21 @@
       "peer": true
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/scheduler": {
-      "version": "0.24.0-canary-efb381bbf-20230505",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.24.0-canary-efb381bbf-20230505.tgz",
-      "integrity": "sha512-ABvovCDe/k9IluqSh4/ISoq8tIJnW8euVAWYt5j/bg6dRnqwQwiGO1F/V4AyK96NGF/FB04FhOUDuWj8IKfABA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "peer": true
+    },
+    "node_modules/@aws-sdk/middleware-retry/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/supports-color": {
@@ -5454,9 +5353,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/middleware-serde": {
       "version": "3.6.1",
@@ -5728,9 +5627,9 @@
       }
     },
     "node_modules/@aws-sdk/util-config-provider/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
       "version": "3.186.0",
@@ -5767,9 +5666,9 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/util-defaults-mode-node": {
       "version": "3.186.0",
@@ -5935,9 +5834,9 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/util-hex-encoding": {
       "version": "3.6.1",
@@ -5951,20 +5850,20 @@
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.568.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
-      "integrity": "sha512-3nh4TINkXYr+H41QaPelCceEB2FXP3fxp93YZXB/kqJvX0U9j0N0Uk45gvsjmEPzG8XxkPEeLIfT2I1M7A6Lig==",
+      "version": "3.723.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.723.0.tgz",
+      "integrity": "sha512-Yf2CS10BqK688DRsrKI/EO6B8ff5J86NXe4C+VCysK7UOgN0l1zOTeTukZ3H8Q9tYYX3oaF1961o8vRkFm7Nmw==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/util-locate-window/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/util-middleware": {
       "version": "3.186.0",
@@ -5978,9 +5877,9 @@
       }
     },
     "node_modules/@aws-sdk/util-middleware/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@aws-sdk/util-uri-escape": {
       "version": "3.6.1",
@@ -6017,17 +5916,12 @@
       }
     },
     "node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.259.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
-      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
+      "integrity": "sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^1.8.0"
       }
-    },
-    "node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@aws-sdk/util-utf8-node": {
       "version": "3.6.1",
@@ -6068,9 +5962,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.2.tgz",
-      "integrity": "sha512-bYcppcpKBvX4znYaPEeFau03bp89ShqNMLs+rmdptMw+heSZh9+z84d2YG+K7cYLbWwzdjtDoW/uqZmPjulClQ==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
+      "integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -6130,25 +6024,26 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.0.tgz",
-      "integrity": "sha512-3LEEcj3PVW8pW2R1SR1M89g/qrYk/m/mB/tLqn7dn4sbBUQyTqnlod+II2U4dqiGtUmkcnAmkMDralTFZttRiw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.10.tgz",
+      "integrity": "sha512-rRHT8siFIXQrAYOYqZQVsAr8vJ+cBNqcVAY6m5V8/4QqzaPl+zDBe6cLEPRDuNOUf3ww8RfJVlOyQMoSI+5Ang==",
       "dependencies": {
-        "@babel/types": "^7.25.0",
+        "@babel/parser": "^7.26.10",
+        "@babel/types": "^7.26.10",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
-        "jsesc": "^2.5.1"
+        "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
-      "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz",
+      "integrity": "sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==",
       "dependencies": {
-        "@babel/types": "^7.24.7"
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -6167,13 +6062,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz",
-      "integrity": "sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz",
+      "integrity": "sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==",
       "dependencies": {
-        "@babel/compat-data": "^7.25.2",
-        "@babel/helper-validator-option": "^7.24.8",
-        "browserslist": "^4.23.1",
+        "@babel/compat-data": "^7.26.5",
+        "@babel/helper-validator-option": "^7.25.9",
+        "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -6182,16 +6077,16 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.0.tgz",
-      "integrity": "sha512-GYM6BxeQsETc9mnct+nIIpf63SAyzvyYN7UB/IlTyd+MBg06afFGp0mIeUqGyWgS2mxad6vqbMrHVlaL3m70sQ==",
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.26.9.tgz",
+      "integrity": "sha512-ubbUqCofvxPRurw5L8WTsCLSkQiVpov4Qx0WMA+jUN+nXBK8ADPlJO1grkFw5CWKC5+sZSOfuGMdX1aI1iT9Sg==",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.24.7",
-        "@babel/helper-member-expression-to-functions": "^7.24.8",
-        "@babel/helper-optimise-call-expression": "^7.24.7",
-        "@babel/helper-replace-supers": "^7.25.0",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
-        "@babel/traverse": "^7.25.0",
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-member-expression-to-functions": "^7.25.9",
+        "@babel/helper-optimise-call-expression": "^7.25.9",
+        "@babel/helper-replace-supers": "^7.26.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
+        "@babel/traverse": "^7.26.9",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -6232,25 +6127,13 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
-    "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
-      "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
-      "peer": true,
-      "dependencies": {
-        "@babel/types": "^7.24.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.8.tgz",
-      "integrity": "sha512-LABppdt+Lp/RlBxqrh4qgf1oEH/WxdzQNDJIu5gC/W1GyvPVrOBiItmmM8wan2fm4oYqFuFfkXmlGpLQhPY8CA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz",
+      "integrity": "sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==",
       "dependencies": {
-        "@babel/traverse": "^7.24.8",
-        "@babel/types": "^7.24.8"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -6286,32 +6169,32 @@
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.24.7.tgz",
-      "integrity": "sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz",
+      "integrity": "sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==",
       "dependencies": {
-        "@babel/types": "^7.24.7"
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
-      "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+      "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-remap-async-to-generator": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.0.tgz",
-      "integrity": "sha512-NhavI2eWEIz/H9dbrG0TuOicDhNexze43i5z7lEqwYm0WEZVTwnPpA0EafUTP7+6/W79HWIP2cTe3Z5NiSTVpw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.9.tgz",
+      "integrity": "sha512-IZtukuUeBbhgOcaW2s06OXTzVNJR0ybm4W5xC1opWFFJMZbwRj5LCk+ByYH7WdZPZTt8KnFwA8pvjN2yqcPlgw==",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.24.7",
-        "@babel/helper-wrap-function": "^7.25.0",
-        "@babel/traverse": "^7.25.0"
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-wrap-function": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -6321,13 +6204,13 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.0.tgz",
-      "integrity": "sha512-q688zIvQVYtZu+i2PsdIu/uWGRpfxzr5WESsfpShfZECkO+d2o+WROWezCi/Q6kJ0tfPa5+pUGUlfx2HhrA3Bg==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.26.5.tgz",
+      "integrity": "sha512-bJ6iIVdYX1YooY2X7w1q6VITt+LnUILtNk7zT78ykuwStx8BauCzxvFqFaHjOpW1bVnSUM1PN1f0p5P21wHxvg==",
       "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.24.8",
-        "@babel/helper-optimise-call-expression": "^7.24.7",
-        "@babel/traverse": "^7.25.0"
+        "@babel/helper-member-expression-to-functions": "^7.25.9",
+        "@babel/helper-optimise-call-expression": "^7.25.9",
+        "@babel/traverse": "^7.26.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -6349,12 +6232,12 @@
       }
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.24.7.tgz",
-      "integrity": "sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.9.tgz",
+      "integrity": "sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==",
       "dependencies": {
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -6377,21 +6260,21 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
-      "integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
+      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-wrap-function": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.25.0.tgz",
-      "integrity": "sha512-s6Q1ebqutSiZnEjaofc/UKDyC4SbzV5n5SrA2Gq8UawLycr3i04f1dX4OzoQVnexm6aOCh37SQNYlJ/8Ku+PMQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.25.9.tgz",
+      "integrity": "sha512-ETzz9UTjQSTmw39GboatdymDq4XIQbR8ySgVrylRhPOFpsd+JrKHIuF0de7GCWmem+T4uC5z7EZguod7Wj4A4g==",
       "dependencies": {
-        "@babel/template": "^7.25.0",
-        "@babel/traverse": "^7.25.0",
-        "@babel/types": "^7.25.0"
+        "@babel/template": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -6497,25 +6380,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.20.7.tgz",
-      "integrity": "sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-async-generator-functions instead.",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/helper-remap-async-to-generator": "^7.18.9",
-        "@babel/plugin-syntax-async-generators": "^7.8.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-proposal-class-properties": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
@@ -6549,30 +6413,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-export-default-from": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.24.7.tgz",
-      "integrity": "sha512-CcmFwUJ3tKhLjPdt4NP+SHMshebytF8ZTYOv5ZDpkzq2sin80Wb5vJrGt8fhPrORQCfoSa0LAxC/DW+GAC5+Hw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.25.9.tgz",
+      "integrity": "sha512-ykqgwNfSnNOB+C8fV5X4mG3AVmvu+WVxcaU9xHHtBb7PCrPeweMmPjGsn8eMaeJg6SJuoUuZENeeSWaarWqonQ==",
       "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7",
-        "@babel/plugin-syntax-export-default-from": "^7.24.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-logical-assignment-operators": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.20.7.tgz",
-      "integrity": "sha512-y7C7cZgpMIjWlKE5T7eJwp+tnRYM89HmRvWM5EQuB5BoHEONjmQ8lSNmBUwOyy/GFRsohJED51YBF79hE1djug==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-logical-assignment-operators instead.",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -6605,43 +6451,6 @@
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-numeric-separator": "^7.10.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.7.tgz",
-      "integrity": "sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.",
-      "peer": true,
-      "dependencies": {
-        "@babel/compat-data": "^7.20.5",
-        "@babel/helper-compilation-targets": "^7.20.7",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.20.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-optional-catch-binding": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.18.6.tgz",
-      "integrity": "sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-catch-binding instead.",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.18.6",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -6775,12 +6584,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-export-default-from": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.24.7.tgz",
-      "integrity": "sha512-bTPz4/635WQ9WhwsyPdxUJDVpsi/X9BMmy/8Rf/UAlOO4jSql4CxUCjWI5PiM+jG+c4LVPTScoTw80geFj9+Bw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.25.9.tgz",
+      "integrity": "sha512-9MhJ/SMTsVqsd69GyQg89lYR4o9T+oDGv5F6IsigxxqFVOyR/IflDLYP8WDI1l8fkhNGGktqkvL5qwNCtGEpgQ==",
       "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -6801,11 +6610,11 @@
       }
     },
     "node_modules/@babel/plugin-syntax-flow": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.24.7.tgz",
-      "integrity": "sha512-9G8GYT/dxn/D1IIKOUBmGX0mnmj46mGH9NnZyJLwtCpgh5f7D2VbuKodb+2s9m1Yavh1s7ASQN8lf0eqrb1LTw==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.26.0.tgz",
+      "integrity": "sha512-B+O2DnPc0iG+YXFqOxv2WNuNU97ToWjOomUQ78DouOENWUaM5sVrmet9mcomUGQFwpJd//gvUagXBSdzO1fRKg==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -7016,14 +6825,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.0.tgz",
-      "integrity": "sha512-uaIi2FdqzjpAMvVqvB51S42oC2JEVgh0LDsGfZVDysWE8LrJtQC2jvKmOqEYThKyB7bDEb7BP1GYWDm7tABA0Q==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.26.8.tgz",
+      "integrity": "sha512-He9Ej2X7tNf2zdKMAGOsmg2MrFc+hfoAhd3po4cWfo/NWjzEAKa0oQruj1ROVUdl0e6fb6/kE/G3SSxE0lRJOg==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.8",
-        "@babel/helper-remap-async-to-generator": "^7.25.0",
-        "@babel/plugin-syntax-async-generators": "^7.8.4",
-        "@babel/traverse": "^7.25.0"
+        "@babel/helper-plugin-utils": "^7.26.5",
+        "@babel/helper-remap-async-to-generator": "^7.25.9",
+        "@babel/traverse": "^7.26.8"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -7077,12 +6885,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-properties": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.24.7.tgz",
-      "integrity": "sha512-vKbfawVYayKcSeSR5YYzzyXvsDFWU2mD8U5TFeXtbCPLFUqe7GyCgvO6XDHzje862ODrOwy6WCPmKeWHbCFJ4w==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.9.tgz",
+      "integrity": "sha512-bbMAII8GRSkcd0h0b4X+36GksxuheLFjP65ul9w6C3KgAamI3JqErNgSrosX6ZPj+Mpim5VvEbawXxJCyEUV3Q==",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.24.7",
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-create-class-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -7108,15 +6916,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.0.tgz",
-      "integrity": "sha512-xyi6qjr/fYU304fiRwFbekzkqVJZ6A7hOjWZd+89FVcBqPV3S9Wuozz82xdpLspckeaafntbzglaW4pqpzvtSw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.9.tgz",
+      "integrity": "sha512-mD8APIXmseE7oZvZgGABDyM34GUmK45Um2TXiBUt7PnuAxrgoSVf123qUzPxEr/+/BHrRn5NMZCdE2m/1F8DGg==",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.24.7",
-        "@babel/helper-compilation-targets": "^7.24.8",
-        "@babel/helper-plugin-utils": "^7.24.8",
-        "@babel/helper-replace-supers": "^7.25.0",
-        "@babel/traverse": "^7.25.0",
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-replace-supers": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -7245,12 +7053,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-flow-strip-types": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.25.2.tgz",
-      "integrity": "sha512-InBZ0O8tew5V0K6cHcQ+wgxlrjOw1W4wDXLkOTjLRD8GYhTSkxTVBtdy3MMtvYBrbAWa1Qm3hNoTc1620Yj+Mg==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.26.5.tgz",
+      "integrity": "sha512-eGK26RsbIkYUns3Y8qKl362juDDYK+wEdPGHGrhzUl6CewZFo55VZ7hg+CyMFU4dd5QQakBN86nBMpRsFpRvbQ==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.8",
-        "@babel/plugin-syntax-flow": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.26.5",
+        "@babel/plugin-syntax-flow": "^7.26.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -7654,12 +7462,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.24.7.tgz",
-      "integrity": "sha512-fOPQYbGSgH0HUp4UJO4sMBFjY6DuWq+2i8rixyUMb3CdGixs/gccURvYOAhajBdKDoGajFr3mUq5rH3phtkGzw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.25.9.tgz",
+      "integrity": "sha512-y8quW6p0WHkEhmErnfe58r7x0A70uKphQm8Sp8cV7tjNQwK56sNVK0M73LK3WuYmsuyrftut4xAkjjgU0twaMg==",
       "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -7669,12 +7477,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.24.7.tgz",
-      "integrity": "sha512-J2z+MWzZHVOemyLweMqngXrgGC42jQ//R0KdxqkIz/OrbVIIlhFI3WigZ5fO+nwFvBlncr4MGapd8vTyc7RPNQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.25.9.tgz",
+      "integrity": "sha512-+iqjT8xmXhhYv4/uiYd8FNQsraMFZIfxVSqxxVSZP0WbbSAWvBXAul0m/zu+7Vv4O/3WtApy9pmaTMiumEZgfg==",
       "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8002,14 +7810,14 @@
       }
     },
     "node_modules/@babel/preset-flow": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.24.7.tgz",
-      "integrity": "sha512-NL3Lo0NorCU607zU3NwRyJbpaB6E3t0xtd3LfAQKDfkeX4/ggcDXvkmkW42QWT5owUeW/jAe4hn+2qvkV1IbfQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.25.9.tgz",
+      "integrity": "sha512-EASHsAhE+SSlEzJ4bzfusnXSHiU+JfAYzj+jbw2vgQKgq5HrUr8qs+vgtiEL5dOH6sEweI+PNt2D7AqrDSHyqQ==",
       "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7",
-        "@babel/helper-validator-option": "^7.24.7",
-        "@babel/plugin-transform-flow-strip-types": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-validator-option": "^7.25.9",
+        "@babel/plugin-transform-flow-strip-types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -8069,9 +7877,9 @@
       }
     },
     "node_modules/@babel/register": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.24.6.tgz",
-      "integrity": "sha512-WSuFCc2wCqMeXkz/i3yfAAsxwWflEgbVkZzivgAmXl/MxrXeoYFZOOPllbC8R8WTF7u61wSRQtDVZ1879cdu6w==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.25.9.tgz",
+      "integrity": "sha512-8D43jXtGsYmEeDvm4MWHYUpWf8iiXgWYx3fW7E7Wb7Oe6FWqJPl5K6TuFW0dOwNZzEE5rjlaSJYH9JjrUKJszA==",
       "peer": true,
       "dependencies": {
         "clone-deep": "^4.0.1",
@@ -8220,15 +8028,34 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.25.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.3.tgz",
-      "integrity": "sha512-HefgyP1x754oGCsKmV5reSmtV7IXj/kpaE1XYY+D9G5PvKKoFfSbiS4M77MdjuwlZKDIKFCffq9rPU+H/s3ZdQ==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.10.tgz",
+      "integrity": "sha512-k8NuDrxr0WrPH5Aupqb2LCVURP/S0vBEn5mK6iH+GIYob66U5EtoZvcdudR2jQ4cmTwhEwW1DLB+Yyas9zjF6A==",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.25.0",
-        "@babel/parser": "^7.25.3",
-        "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.2",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.10",
+        "@babel/parser": "^7.26.10",
+        "@babel/template": "^7.26.9",
+        "@babel/types": "^7.26.10",
+        "debug": "^4.3.1",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse--for-generate-function-map": {
+      "name": "@babel/traverse",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.10.tgz",
+      "integrity": "sha512-k8NuDrxr0WrPH5Aupqb2LCVURP/S0vBEn5mK6iH+GIYob66U5EtoZvcdudR2jQ4cmTwhEwW1DLB+Yyas9zjF6A==",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.10",
+        "@babel/parser": "^7.26.10",
+        "@babel/template": "^7.26.9",
+        "@babel/types": "^7.26.10",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -8700,21 +8527,6 @@
       "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-      "peer": true
-    },
-    "node_modules/@hapi/topo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-      "peer": true,
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -10289,7 +10101,6 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
       "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
-      "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/types": "^29.6.3",
@@ -10315,7 +10126,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -10330,7 +10140,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -10346,7 +10155,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -10357,14 +10165,12 @@
     "node_modules/@jest/transform/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/@jest/transform/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -10373,7 +10179,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -10691,1192 +10496,77 @@
       "resolved": "https://registry.npmjs.org/@reach/observe-rect/-/observe-rect-1.2.0.tgz",
       "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ=="
     },
-    "node_modules/@react-native-community/cli": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-13.6.9.tgz",
-      "integrity": "sha512-hFJL4cgLPxncJJd/epQ4dHnMg5Jy/7Q56jFvA3MHViuKpzzfTCJCB+pGY54maZbtym53UJON9WTGpM3S81UfjQ==",
-      "peer": true,
-      "dependencies": {
-        "@react-native-community/cli-clean": "13.6.9",
-        "@react-native-community/cli-config": "13.6.9",
-        "@react-native-community/cli-debugger-ui": "13.6.9",
-        "@react-native-community/cli-doctor": "13.6.9",
-        "@react-native-community/cli-hermes": "13.6.9",
-        "@react-native-community/cli-server-api": "13.6.9",
-        "@react-native-community/cli-tools": "13.6.9",
-        "@react-native-community/cli-types": "13.6.9",
-        "chalk": "^4.1.2",
-        "commander": "^9.4.1",
-        "deepmerge": "^4.3.0",
-        "execa": "^5.0.0",
-        "find-up": "^4.1.0",
-        "fs-extra": "^8.1.0",
-        "graceful-fs": "^4.1.3",
-        "prompts": "^2.4.2",
-        "semver": "^7.5.2"
-      },
-      "bin": {
-        "rnc-cli": "build/bin.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@react-native-community/cli-clean": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-clean/-/cli-clean-13.6.9.tgz",
-      "integrity": "sha512-7Dj5+4p9JggxuVNOjPbduZBAP1SUgNhLKVw5noBUzT/3ZpUZkDM+RCSwyoyg8xKWoE4OrdUAXwAFlMcFDPKykA==",
-      "peer": true,
-      "dependencies": {
-        "@react-native-community/cli-tools": "13.6.9",
-        "chalk": "^4.1.2",
-        "execa": "^5.0.0",
-        "fast-glob": "^3.3.2"
-      }
-    },
-    "node_modules/@react-native-community/cli-clean/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@react-native-community/cli-clean/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@react-native-community/cli-clean/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-clean/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
-    },
-    "node_modules/@react-native-community/cli-clean/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-clean/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-config": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-config/-/cli-config-13.6.9.tgz",
-      "integrity": "sha512-rFfVBcNojcMm+KKHE/xqpqXg8HoKl4EC7bFHUrahMJ+y/tZll55+oX/PGG37rzB8QzP2UbMQ19DYQKC1G7kXeg==",
-      "peer": true,
-      "dependencies": {
-        "@react-native-community/cli-tools": "13.6.9",
-        "chalk": "^4.1.2",
-        "cosmiconfig": "^5.1.0",
-        "deepmerge": "^4.3.0",
-        "fast-glob": "^3.3.2",
-        "joi": "^17.2.1"
-      }
-    },
-    "node_modules/@react-native-community/cli-config/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@react-native-community/cli-config/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@react-native-community/cli-config/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-config/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
-    },
-    "node_modules/@react-native-community/cli-config/node_modules/cosmiconfig": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
-      "peer": true,
-      "dependencies": {
-        "import-fresh": "^2.0.0",
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.13.1",
-        "parse-json": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@react-native-community/cli-config/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-config/node_modules/import-fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-      "integrity": "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==",
-      "peer": true,
-      "dependencies": {
-        "caller-path": "^2.0.0",
-        "resolve-from": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@react-native-community/cli-config/node_modules/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
-      "peer": true,
-      "dependencies": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@react-native-community/cli-config/node_modules/resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@react-native-community/cli-config/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-debugger-ui": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-13.6.9.tgz",
-      "integrity": "sha512-TkN7IdFmGPPvTpAo3nCAH9uwGCPxWBEAwpqEZDrq0NWllI7Tdie8vDpGdrcuCcKalmhq6OYnkXzeBah7O1Ztpw==",
-      "peer": true,
-      "dependencies": {
-        "serve-static": "^1.13.1"
-      }
-    },
-    "node_modules/@react-native-community/cli-doctor": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-13.6.9.tgz",
-      "integrity": "sha512-5quFaLdWFQB+677GXh5dGU9I5eg2z6Vg4jOX9vKnc9IffwyIFAyJfCZHrxLSRPDGNXD7biDQUdoezXYGwb6P/A==",
-      "peer": true,
-      "dependencies": {
-        "@react-native-community/cli-config": "13.6.9",
-        "@react-native-community/cli-platform-android": "13.6.9",
-        "@react-native-community/cli-platform-apple": "13.6.9",
-        "@react-native-community/cli-platform-ios": "13.6.9",
-        "@react-native-community/cli-tools": "13.6.9",
-        "chalk": "^4.1.2",
-        "command-exists": "^1.2.8",
-        "deepmerge": "^4.3.0",
-        "envinfo": "^7.10.0",
-        "execa": "^5.0.0",
-        "hermes-profile-transformer": "^0.0.6",
-        "node-stream-zip": "^1.9.1",
-        "ora": "^5.4.1",
-        "semver": "^7.5.2",
-        "strip-ansi": "^5.2.0",
-        "wcwidth": "^1.0.1",
-        "yaml": "^2.2.1"
-      }
-    },
-    "node_modules/@react-native-community/cli-doctor/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@react-native-community/cli-doctor/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@react-native-community/cli-doctor/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@react-native-community/cli-doctor/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-doctor/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
-    },
-    "node_modules/@react-native-community/cli-doctor/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-doctor/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@react-native-community/cli-doctor/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@react-native-community/cli-doctor/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-doctor/node_modules/yaml": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.0.tgz",
-      "integrity": "sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==",
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@react-native-community/cli-hermes": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-13.6.9.tgz",
-      "integrity": "sha512-GvwiwgvFw4Ws+krg2+gYj8sR3g05evmNjAHkKIKMkDTJjZ8EdyxbkifRUs1ZCq3TMZy2oeblZBXCJVOH4W7ZbA==",
-      "peer": true,
-      "dependencies": {
-        "@react-native-community/cli-platform-android": "13.6.9",
-        "@react-native-community/cli-tools": "13.6.9",
-        "chalk": "^4.1.2",
-        "hermes-profile-transformer": "^0.0.6"
-      }
-    },
-    "node_modules/@react-native-community/cli-hermes/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@react-native-community/cli-hermes/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@react-native-community/cli-hermes/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-hermes/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
-    },
-    "node_modules/@react-native-community/cli-hermes/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-hermes/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-platform-android": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-13.6.9.tgz",
-      "integrity": "sha512-9KsYGdr08QhdvT3Ht7e8phQB3gDX9Fs427NJe0xnoBh+PDPTI2BD5ks5ttsH8CzEw8/P6H8tJCHq6hf2nxd9cw==",
-      "peer": true,
-      "dependencies": {
-        "@react-native-community/cli-tools": "13.6.9",
-        "chalk": "^4.1.2",
-        "execa": "^5.0.0",
-        "fast-glob": "^3.3.2",
-        "fast-xml-parser": "^4.2.4",
-        "logkitty": "^0.7.1"
-      }
-    },
-    "node_modules/@react-native-community/cli-platform-android/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@react-native-community/cli-platform-android/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@react-native-community/cli-platform-android/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-platform-android/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
-    },
-    "node_modules/@react-native-community/cli-platform-android/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-platform-android/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-platform-apple": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-apple/-/cli-platform-apple-13.6.9.tgz",
-      "integrity": "sha512-KoeIHfhxMhKXZPXmhQdl6EE+jGKWwoO9jUVWgBvibpVmsNjo7woaG/tfJMEWfWF3najX1EkQAoJWpCDBMYWtlA==",
-      "peer": true,
-      "dependencies": {
-        "@react-native-community/cli-tools": "13.6.9",
-        "chalk": "^4.1.2",
-        "execa": "^5.0.0",
-        "fast-glob": "^3.3.2",
-        "fast-xml-parser": "^4.0.12",
-        "ora": "^5.4.1"
-      }
-    },
-    "node_modules/@react-native-community/cli-platform-apple/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@react-native-community/cli-platform-apple/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@react-native-community/cli-platform-apple/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-platform-apple/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
-    },
-    "node_modules/@react-native-community/cli-platform-apple/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-platform-apple/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-platform-ios": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-13.6.9.tgz",
-      "integrity": "sha512-CiUcHlGs8vE0CAB4oi1f+dzniqfGuhWPNrDvae2nm8dewlahTBwIcK5CawyGezjcJoeQhjBflh9vloska+nlnw==",
-      "peer": true,
-      "dependencies": {
-        "@react-native-community/cli-platform-apple": "13.6.9"
-      }
-    },
-    "node_modules/@react-native-community/cli-server-api": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-13.6.9.tgz",
-      "integrity": "sha512-W8FSlCPWymO+tlQfM3E0JmM8Oei5HZsIk5S0COOl0MRi8h0NmHI4WSTF2GCfbFZkcr2VI/fRsocoN8Au4EZAug==",
-      "peer": true,
-      "dependencies": {
-        "@react-native-community/cli-debugger-ui": "13.6.9",
-        "@react-native-community/cli-tools": "13.6.9",
-        "compression": "^1.7.1",
-        "connect": "^3.6.5",
-        "errorhandler": "^1.5.1",
-        "nocache": "^3.0.1",
-        "pretty-format": "^26.6.2",
-        "serve-static": "^1.13.1",
-        "ws": "^6.2.2"
-      }
-    },
-    "node_modules/@react-native-community/cli-server-api/node_modules/@jest/types": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-      "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
-      "peer": true,
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^15.0.0",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 10.14.2"
-      }
-    },
-    "node_modules/@react-native-community/cli-server-api/node_modules/@types/yargs": {
-      "version": "15.0.19",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.19.tgz",
-      "integrity": "sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==",
-      "peer": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@react-native-community/cli-server-api/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@react-native-community/cli-server-api/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@react-native-community/cli-server-api/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-server-api/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
-    },
-    "node_modules/@react-native-community/cli-server-api/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-server-api/node_modules/pretty-format": {
-      "version": "26.6.2",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-      "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
-      "peer": true,
-      "dependencies": {
-        "@jest/types": "^26.6.2",
-        "ansi-regex": "^5.0.0",
-        "ansi-styles": "^4.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@react-native-community/cli-server-api/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-server-api/node_modules/ws": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
-      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
-      "peer": true,
-      "dependencies": {
-        "async-limiter": "~1.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-tools": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-13.6.9.tgz",
-      "integrity": "sha512-OXaSjoN0mZVw3nrAwcY1PC0uMfyTd9fz7Cy06dh+EJc+h0wikABsVRzV8cIOPrVV+PPEEXE0DBrH20T2puZzgQ==",
-      "peer": true,
-      "dependencies": {
-        "appdirsjs": "^1.2.4",
-        "chalk": "^4.1.2",
-        "execa": "^5.0.0",
-        "find-up": "^5.0.0",
-        "mime": "^2.4.1",
-        "node-fetch": "^2.6.0",
-        "open": "^6.2.0",
-        "ora": "^5.4.1",
-        "semver": "^7.5.2",
-        "shell-quote": "^1.7.3",
-        "sudo-prompt": "^9.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-tools/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@react-native-community/cli-tools/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@react-native-community/cli-tools/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-tools/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
-    },
-    "node_modules/@react-native-community/cli-tools/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "peer": true,
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@react-native-community/cli-tools/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-tools/node_modules/is-wsl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@react-native-community/cli-tools/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "peer": true,
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@react-native-community/cli-tools/node_modules/mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "peer": true,
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-tools/node_modules/open": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
-      "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
-      "peer": true,
-      "dependencies": {
-        "is-wsl": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-tools/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "peer": true,
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@react-native-community/cli-tools/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "peer": true,
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@react-native-community/cli-tools/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@react-native-community/cli-tools/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-types": {
-      "version": "13.6.9",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-13.6.9.tgz",
-      "integrity": "sha512-RLxDppvRxXfs3hxceW/mShi+6o5yS+kFPnPqZTaMKKR5aSg7LwDpLQW4K2D22irEG8e6RKDkZUeH9aL3vO2O0w==",
-      "peer": true,
-      "dependencies": {
-        "joi": "^17.2.1"
-      }
-    },
-    "node_modules/@react-native-community/cli/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@react-native-community/cli/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@react-native-community/cli/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
-    },
-    "node_modules/@react-native-community/cli/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "peer": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
-    "node_modules/@react-native-community/cli/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@react-native-community/cli/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "peer": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@react-native-community/cli/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@react-native-community/cli/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "peer": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/@react-native/assets-registry": {
-      "version": "0.74.86",
-      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.74.86.tgz",
-      "integrity": "sha512-rNWSa1MTqG3Z7ZfACIDlED+T63tNlt0Lr/ruvxFJL5IX6DRC6sIrb2SrbLrlXgz7C0FbhO0ub9zfHXISgrJOsQ==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.78.0.tgz",
+      "integrity": "sha512-PPHlTRuP9litTYkbFNkwveQFto3I94QRWPBBARU0cH/4ks4EkfCfb/Pdb3AHgtJi58QthSHKFvKTQnAWyHPs7w==",
       "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/babel-plugin-codegen": {
-      "version": "0.74.86",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.74.86.tgz",
-      "integrity": "sha512-fO7exk0pdsOSsK3fvDz4YKe5nMeAMrsIGi525pft/L+dedjdeiWYmEoQVc9NElxwwNCldwRY6eNMw6IhKyjzLA==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.78.0.tgz",
+      "integrity": "sha512-+Sy9Uine0QAbQRxMl6kBlkzKW0qHQk8hghCoKswRWt1ZfxaMA3rezobD5mtSwt/Yhadds9cGbMFWfFJM3Tynsg==",
       "peer": true,
       "dependencies": {
-        "@react-native/codegen": "0.74.86"
+        "@babel/traverse": "^7.25.3",
+        "@react-native/codegen": "0.78.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/babel-preset": {
-      "version": "0.74.86",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.74.86.tgz",
-      "integrity": "sha512-6A+1NVAHugbBLFNU4iaYrq2lx8P7pINyqoyTtVAqd375PShRmLwu6GvuF3b/4avC97s6LmBljVTJ1xVHukA42g==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.78.0.tgz",
+      "integrity": "sha512-q44ZbR0JXdPvNrjNw75VmiVXXoJhZIx8dTUBVgnZx/UHBQuhPu0e8pAuo56E2mZVkF7FK0s087/Zji8n5OSxbQ==",
       "peer": true,
       "dependencies": {
-        "@babel/core": "^7.20.0",
-        "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
-        "@babel/plugin-proposal-class-properties": "^7.18.0",
-        "@babel/plugin-proposal-export-default-from": "^7.0.0",
-        "@babel/plugin-proposal-logical-assignment-operators": "^7.18.0",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.0",
-        "@babel/plugin-proposal-numeric-separator": "^7.0.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.20.0",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
-        "@babel/plugin-proposal-optional-chaining": "^7.20.0",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.0",
-        "@babel/plugin-syntax-export-default-from": "^7.0.0",
-        "@babel/plugin-syntax-flow": "^7.18.0",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.0.0",
-        "@babel/plugin-syntax-optional-chaining": "^7.0.0",
-        "@babel/plugin-transform-arrow-functions": "^7.0.0",
-        "@babel/plugin-transform-async-to-generator": "^7.20.0",
-        "@babel/plugin-transform-block-scoping": "^7.0.0",
-        "@babel/plugin-transform-classes": "^7.0.0",
-        "@babel/plugin-transform-computed-properties": "^7.0.0",
-        "@babel/plugin-transform-destructuring": "^7.20.0",
-        "@babel/plugin-transform-flow-strip-types": "^7.20.0",
-        "@babel/plugin-transform-function-name": "^7.0.0",
-        "@babel/plugin-transform-literals": "^7.0.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.0.0",
-        "@babel/plugin-transform-parameters": "^7.0.0",
-        "@babel/plugin-transform-private-methods": "^7.22.5",
-        "@babel/plugin-transform-private-property-in-object": "^7.22.11",
-        "@babel/plugin-transform-react-display-name": "^7.0.0",
-        "@babel/plugin-transform-react-jsx": "^7.0.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.0.0",
-        "@babel/plugin-transform-react-jsx-source": "^7.0.0",
-        "@babel/plugin-transform-runtime": "^7.0.0",
-        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
-        "@babel/plugin-transform-spread": "^7.0.0",
-        "@babel/plugin-transform-sticky-regex": "^7.0.0",
-        "@babel/plugin-transform-typescript": "^7.5.0",
-        "@babel/plugin-transform-unicode-regex": "^7.0.0",
-        "@babel/template": "^7.0.0",
-        "@react-native/babel-plugin-codegen": "0.74.86",
+        "@babel/core": "^7.25.2",
+        "@babel/plugin-proposal-export-default-from": "^7.24.7",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-syntax-export-default-from": "^7.24.7",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-transform-arrow-functions": "^7.24.7",
+        "@babel/plugin-transform-async-generator-functions": "^7.25.4",
+        "@babel/plugin-transform-async-to-generator": "^7.24.7",
+        "@babel/plugin-transform-block-scoping": "^7.25.0",
+        "@babel/plugin-transform-class-properties": "^7.25.4",
+        "@babel/plugin-transform-classes": "^7.25.4",
+        "@babel/plugin-transform-computed-properties": "^7.24.7",
+        "@babel/plugin-transform-destructuring": "^7.24.8",
+        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
+        "@babel/plugin-transform-for-of": "^7.24.7",
+        "@babel/plugin-transform-function-name": "^7.25.1",
+        "@babel/plugin-transform-literals": "^7.25.2",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.24.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
+        "@babel/plugin-transform-numeric-separator": "^7.24.7",
+        "@babel/plugin-transform-object-rest-spread": "^7.24.7",
+        "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
+        "@babel/plugin-transform-optional-chaining": "^7.24.8",
+        "@babel/plugin-transform-parameters": "^7.24.7",
+        "@babel/plugin-transform-private-methods": "^7.24.7",
+        "@babel/plugin-transform-private-property-in-object": "^7.24.7",
+        "@babel/plugin-transform-react-display-name": "^7.24.7",
+        "@babel/plugin-transform-react-jsx": "^7.25.2",
+        "@babel/plugin-transform-react-jsx-self": "^7.24.7",
+        "@babel/plugin-transform-react-jsx-source": "^7.24.7",
+        "@babel/plugin-transform-regenerator": "^7.24.7",
+        "@babel/plugin-transform-runtime": "^7.24.7",
+        "@babel/plugin-transform-shorthand-properties": "^7.24.7",
+        "@babel/plugin-transform-spread": "^7.24.7",
+        "@babel/plugin-transform-sticky-regex": "^7.24.7",
+        "@babel/plugin-transform-typescript": "^7.25.2",
+        "@babel/plugin-transform-unicode-regex": "^7.24.7",
+        "@babel/template": "^7.25.0",
+        "@react-native/babel-plugin-codegen": "0.78.0",
+        "babel-plugin-syntax-hermes-parser": "0.25.1",
         "babel-plugin-transform-flow-enums": "^0.0.2",
         "react-refresh": "^0.14.0"
       },
@@ -11897,18 +10587,18 @@
       }
     },
     "node_modules/@react-native/codegen": {
-      "version": "0.74.86",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.74.86.tgz",
-      "integrity": "sha512-BOwABta9035GJ/zLMkxQfgPMr47u1/1HqNIMk10FqmTe0jmROOxKEAeP4FbeS5L1voO4ug3dqr+mcuHrG+HNhA==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.78.0.tgz",
+      "integrity": "sha512-8iVT2VYhkalLFUWoQRGSluZZHEG93StfwQGwQ+wk1vOUlOfoT/Xqglt6DvGXIyM9gaMCr6fJBFQVrU+FrXEFYA==",
       "peer": true,
       "dependencies": {
-        "@babel/parser": "^7.20.0",
+        "@babel/parser": "^7.25.3",
         "glob": "^7.1.1",
-        "hermes-parser": "0.19.1",
+        "hermes-parser": "0.25.1",
         "invariant": "^2.2.4",
-        "jscodeshift": "^0.14.0",
-        "mkdirp": "^0.5.1",
-        "nullthrows": "^1.1.1"
+        "jscodeshift": "^17.0.0",
+        "nullthrows": "^1.1.1",
+        "yargs": "^17.6.2"
       },
       "engines": {
         "node": ">=18"
@@ -11918,26 +10608,32 @@
       }
     },
     "node_modules/@react-native/community-cli-plugin": {
-      "version": "0.74.86",
-      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.74.86.tgz",
-      "integrity": "sha512-q0fPDe6vx1vT5PdE3AiL+DNm0q7opzySiGle8B64bAKsa0ClIoRXAzZqolceiMHbSoCIhUbZxYtNGavrjuPyKw==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.78.0.tgz",
+      "integrity": "sha512-LpfEU+F1hZGcxIf07aBrjlImA0hh8v76V4wTJOgxxqGDUjjQ/X6h9V+bMXne60G9gwccTtvs1G0xiKWNUPI0VQ==",
       "peer": true,
       "dependencies": {
-        "@react-native-community/cli-server-api": "13.6.9",
-        "@react-native-community/cli-tools": "13.6.9",
-        "@react-native/dev-middleware": "0.74.86",
-        "@react-native/metro-babel-transformer": "0.74.86",
+        "@react-native/dev-middleware": "0.78.0",
+        "@react-native/metro-babel-transformer": "0.78.0",
         "chalk": "^4.0.0",
-        "execa": "^5.1.1",
-        "metro": "^0.80.3",
-        "metro-config": "^0.80.3",
-        "metro-core": "^0.80.3",
-        "node-fetch": "^2.2.0",
-        "querystring": "^0.2.1",
-        "readline": "^1.3.0"
+        "debug": "^2.2.0",
+        "invariant": "^2.2.4",
+        "metro": "^0.81.0",
+        "metro-config": "^0.81.0",
+        "metro-core": "^0.81.0",
+        "readline": "^1.3.0",
+        "semver": "^7.1.3"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@react-native-community/cli-server-api": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-community/cli-server-api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/ansi-styles": {
@@ -11989,6 +10685,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "peer": true
     },
+    "node_modules/@react-native/community-cli-plugin/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "peer": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
     "node_modules/@react-native/community-cli-plugin/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -11998,14 +10703,22 @@
         "node": ">=8"
       }
     },
-    "node_modules/@react-native/community-cli-plugin/node_modules/querystring": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
-      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+    "node_modules/@react-native/community-cli-plugin/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "peer": true
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
       "engines": {
-        "node": ">=0.4.x"
+        "node": ">=10"
       }
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/supports-color": {
@@ -12021,33 +10734,32 @@
       }
     },
     "node_modules/@react-native/debugger-frontend": {
-      "version": "0.74.86",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.74.86.tgz",
-      "integrity": "sha512-Spq1kFX4qvPmT4HuTwpi1ALFtojlJ6s4GpWU2OnpevC/z7ks36lhD3J0rd0D9U5bkxtTYLcg31fPv7nGFC7XZg==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.78.0.tgz",
+      "integrity": "sha512-KQYD9QlxES/VdmXh9EEvtZCJK1KAemLlszQq4dpLU1stnue5N8dnCY6A7PpStMf5UtAMk7tiniQhaicw0uVHgQ==",
       "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/dev-middleware": {
-      "version": "0.74.86",
-      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.74.86.tgz",
-      "integrity": "sha512-sc0tYxYt6dkUbNFI1IANzKO67M41BhjbJ6k/CHoFi/tGoNmHzg9IUZ89V4g3H8hn/VW9dETnPOFna1VO0sWrXg==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.78.0.tgz",
+      "integrity": "sha512-zEafAZdOz4s37Jh5Xcv4hJE5qZ6uNxgrTLcpjDOJnQG6dO34/BoZeXvDrjomQFNn6ogdysR51mKJStaQ3ixp5A==",
       "peer": true,
       "dependencies": {
         "@isaacs/ttlcache": "^1.4.1",
-        "@react-native/debugger-frontend": "0.74.86",
-        "@rnx-kit/chromium-edge-launcher": "^1.0.0",
+        "@react-native/debugger-frontend": "0.78.0",
         "chrome-launcher": "^0.15.2",
+        "chromium-edge-launcher": "^0.2.0",
         "connect": "^3.6.5",
         "debug": "^2.2.0",
-        "node-fetch": "^2.2.0",
+        "invariant": "^2.2.4",
         "nullthrows": "^1.1.1",
         "open": "^7.0.3",
         "selfsigned": "^2.4.1",
-        "serve-static": "^1.13.1",
-        "temp-dir": "^2.0.0",
-        "ws": "^6.2.2"
+        "serve-static": "^1.16.2",
+        "ws": "^6.2.3"
       },
       "engines": {
         "node": ">=18"
@@ -12094,32 +10806,32 @@
       }
     },
     "node_modules/@react-native/gradle-plugin": {
-      "version": "0.74.86",
-      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.74.86.tgz",
-      "integrity": "sha512-aoYeX7mjf3Efwc5t8AdcwC42oicMRKauGMZimvXY3xqfYV97G4foAYXrxQYZsMaxecFStdYMiXWyMFO/UFmEpA==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.78.0.tgz",
+      "integrity": "sha512-WvwgfmVs1QfFl1FOL514kz2Fs5Nkg2BGgpE8V0ild8b/UT6jCD8qh2dTI5kL0xdT0d2Xd2BxfuFN0xCLkMC+SA==",
       "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/js-polyfills": {
-      "version": "0.74.86",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.74.86.tgz",
-      "integrity": "sha512-Yrsj4a1rTkk618LUJJxOWFnyAZR3sHmXJwcj4qupkJs+ou3aDkixfXgVVrvQP39iBptaQvCpo7PSqs+LjSNYbA==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.78.0.tgz",
+      "integrity": "sha512-YZ9XtS77s/df7548B6dszX89ReehnA7hiab/axc30j/Mgk7Wv2woOjBKnAA4+rZ0ITLtxNwyJIMaRAc9kGznXw==",
       "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/metro-babel-transformer": {
-      "version": "0.74.86",
-      "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.74.86.tgz",
-      "integrity": "sha512-/9qN5zcnTHGDkC4jWibnoGmRnzDXiurl5wmkvspgnsdrJINN6eGpK8sdIn6nrHFOuPlp3Metqw3HkxbuAfNUXw==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.78.0.tgz",
+      "integrity": "sha512-Hy/dl+zytLCRD9dp32ukcRS1Bn0gZH0h0i3AbriS6OGYgUgjAUFhXOKzZ15/G1SEq2sng91MNo/hMvo4uXoc5A==",
       "peer": true,
       "dependencies": {
-        "@babel/core": "^7.20.0",
-        "@react-native/babel-preset": "0.74.86",
-        "hermes-parser": "0.19.1",
+        "@babel/core": "^7.25.2",
+        "@react-native/babel-preset": "0.78.0",
+        "hermes-parser": "0.25.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -12130,9 +10842,9 @@
       }
     },
     "node_modules/@react-native/normalize-colors": {
-      "version": "0.74.86",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.74.86.tgz",
-      "integrity": "sha512-GGA+nhwrQ1umwnkv7tuGbGIk0oBTeNbG4cUxNQX/CbYW0R98RCNxSbXjfw1XnXZd3lCSFLDxzw154V4hum2pNQ==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.78.0.tgz",
+      "integrity": "sha512-FkeLvLLaMYlGsSntixTUvlNtc1OHij4TYRtymMNPWqBKFAMXJB/qe45VxXNzWP+jD0Ok6yXineQFtktKcHk9PA==",
       "peer": true
     },
     "node_modules/@remix-run/router": {
@@ -12141,47 +10853,6 @@
       "integrity": "sha512-zDICCLKEwbVYTS6TjYaWtHXxkdoUvD/QXvyVZjGCsWz5vyH7aFeONlPffPdW+Y/t6KT0MgXb2Mfjun9YpWN1dA==",
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@rnx-kit/chromium-edge-launcher": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@rnx-kit/chromium-edge-launcher/-/chromium-edge-launcher-1.0.0.tgz",
-      "integrity": "sha512-lzD84av1ZQhYUS+jsGqJiCMaJO2dn9u+RTT9n9q6D3SaKVwWqv+7AoRKqBu19bkwyE+iFRl1ymr40QS90jVFYg==",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "^18.0.0",
-        "escape-string-regexp": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "lighthouse-logger": "^1.0.0",
-        "mkdirp": "^1.0.4",
-        "rimraf": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=14.15"
-      }
-    },
-    "node_modules/@rnx-kit/chromium-edge-launcher/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@rnx-kit/chromium-edge-launcher/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "peer": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -12263,27 +10934,6 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.4.tgz",
       "integrity": "sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA=="
     },
-    "node_modules/@sideway/address": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
-      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
-      "peer": true,
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@sideway/formula": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
-      "peer": true
-    },
-    "node_modules/@sideway/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-      "peer": true
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -12306,20 +10956,20 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.1.0.tgz",
+      "integrity": "sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/types/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -13903,9 +12553,9 @@
       }
     },
     "node_modules/amazon-cognito-identity-js": {
-      "version": "6.3.13",
-      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-6.3.13.tgz",
-      "integrity": "sha512-AOROAQHQYvXYnhzhB9L1cZdz+linq/xaPTBfXhvXsx1tyhbbzmA7HX8Ap3mKBPsjsG8UWfzDhdRCb7hmH3S14A==",
+      "version": "6.3.14",
+      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-6.3.14.tgz",
+      "integrity": "sha512-nxN8L5AAwLIsgQKyKMOsNwr5xeY7+fccv+A/ALiYxmGiM341XX0dcoMuM+LlJmzfIfuPmTrXSehhTunTTQFAow==",
       "dependencies": {
         "@aws-crypto/sha256-js": "1.2.2",
         "buffer": "4.9.2",
@@ -13943,44 +12593,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-fragments": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-fragments/-/ansi-fragments-0.2.1.tgz",
-      "integrity": "sha512-DykbNHxuXQwUDRv5ibc2b0x7uw7wmwOGLBUd5RmaQ5z8Lhx19vwvKV+FAsM5rEA6dEcHxX+/Ad5s9eF2k2bB+w==",
-      "peer": true,
-      "dependencies": {
-        "colorette": "^1.0.7",
-        "slice-ansi": "^2.0.0",
-        "strip-ansi": "^5.0.0"
-      }
-    },
-    "node_modules/ansi-fragments/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ansi-fragments/node_modules/colorette": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
-      "peer": true
-    },
-    "node_modules/ansi-fragments/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/ansi-html": {
@@ -14040,12 +12652,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/appdirsjs": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/appdirsjs/-/appdirsjs-1.2.7.tgz",
-      "integrity": "sha512-Quji6+8kLBC3NnBeo14nPDq0+2jUs5s3/xEye+udFHumHhRk4M7aAMXp/PBJqkKYGuuyR9M/6Dq7d2AViiGmhw==",
-      "peer": true
     },
     "node_modules/arg": {
       "version": "5.0.2",
@@ -14249,9 +12855,9 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "node_modules/ast-types": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.15.2.tgz",
-      "integrity": "sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.0.1"
@@ -14266,19 +12872,10 @@
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ=="
     },
     "node_modules/ast-types/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "peer": true
-    },
-    "node_modules/astral-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/async": {
       "version": "3.2.5",
@@ -14355,22 +12952,22 @@
       }
     },
     "node_modules/aws-amplify": {
-      "version": "5.3.19",
-      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-5.3.19.tgz",
-      "integrity": "sha512-/Sbgow1Zfe5RDnKyVlNZblaDuphz2g7IPBF6w6NKnM1JfuVCREHb5FwKUPr5RzfH8JAdCh/OFiCqhLDk2wo7dw==",
+      "version": "5.3.27",
+      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-5.3.27.tgz",
+      "integrity": "sha512-L4impLEBZKwNWRuM8jyfV4IUkGlh0ayLM1yRabd/Gm50leY8VSUbq5eXYhHzZpE2xcuqqIhuySo6Ui/y0gZ/iQ==",
       "dependencies": {
-        "@aws-amplify/analytics": "6.5.12",
-        "@aws-amplify/api": "5.4.12",
-        "@aws-amplify/auth": "5.6.12",
-        "@aws-amplify/cache": "5.1.18",
-        "@aws-amplify/core": "5.8.12",
-        "@aws-amplify/datastore": "4.7.12",
-        "@aws-amplify/geo": "2.3.12",
-        "@aws-amplify/interactions": "5.2.18",
-        "@aws-amplify/notifications": "1.6.13",
-        "@aws-amplify/predictions": "5.5.12",
-        "@aws-amplify/pubsub": "5.5.12",
-        "@aws-amplify/storage": "5.9.12",
+        "@aws-amplify/analytics": "6.5.14",
+        "@aws-amplify/api": "5.4.16",
+        "@aws-amplify/auth": "5.6.15",
+        "@aws-amplify/cache": "5.1.20",
+        "@aws-amplify/core": "5.8.14",
+        "@aws-amplify/datastore": "4.7.16",
+        "@aws-amplify/geo": "2.3.14",
+        "@aws-amplify/interactions": "5.2.21",
+        "@aws-amplify/notifications": "1.6.16",
+        "@aws-amplify/predictions": "5.5.17",
+        "@aws-amplify/pubsub": "5.6.2",
+        "@aws-amplify/storage": "5.9.16",
         "tslib": "^2.0.0"
       }
     },
@@ -14388,9 +12985,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
-      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
+      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -14398,12 +12995,13 @@
       }
     },
     "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -14418,20 +13016,10 @@
         "deep-equal": "^2.0.5"
       }
     },
-    "node_modules/babel-core": {
-      "version": "7.0.0-bridge.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
-      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-      "peer": true,
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
       "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
-      "dev": true,
       "dependencies": {
         "@jest/transform": "^29.7.0",
         "@types/babel__core": "^7.1.14",
@@ -14452,7 +13040,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -14467,7 +13054,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -14483,7 +13069,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -14494,14 +13079,12 @@
     "node_modules/babel-jest/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/babel-jest/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -14510,7 +13093,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -14572,7 +13154,6 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
       "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
-      "dev": true,
       "dependencies": {
         "@babel/template": "^7.3.3",
         "@babel/types": "^7.3.3",
@@ -14641,6 +13222,15 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
+    "node_modules/babel-plugin-syntax-hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-IVNpGzboFLfXZUAwkLFcI/bnqVbwky0jP3eBno4HKtqvQJAHBLdgxiG6lQ4to0+Q/YCN3PO0od5NZwIKyY4REQ==",
+      "peer": true,
+      "dependencies": {
+        "hermes-parser": "0.25.1"
+      }
+    },
     "node_modules/babel-plugin-transform-flow-enums": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-enums/-/babel-plugin-transform-flow-enums-0.0.2.tgz",
@@ -14681,7 +13271,6 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
       "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
-      "dev": true,
       "dependencies": {
         "babel-plugin-jest-hoist": "^29.6.3",
         "babel-preset-current-node-syntax": "^1.0.0"
@@ -14788,6 +13377,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -14798,6 +13388,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14911,9 +13502,9 @@
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
     },
     "node_modules/browserslist": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.2.tgz",
-      "integrity": "sha512-qkqSyistMYdxAcw+CzbZwlBy8AGmS/eEWs+sEV5TnLRGDOL+C5M2EnH6tlZyg0YoAxGJAFKh61En9BR941GnHA==",
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
       "funding": [
         {
           "type": "opencollective",
@@ -14929,10 +13520,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001640",
-        "electron-to-chromium": "^1.4.820",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.1.0"
+        "caniuse-lite": "^1.0.30001688",
+        "electron-to-chromium": "^1.5.73",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.1"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -14999,6 +13590,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/caller-callsite": {
@@ -15100,9 +13703,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001646",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001646.tgz",
-      "integrity": "sha512-dRg00gudiBDDTmUhClSdv3hqRfpbOnU28IpI1T6PBTLWa+kOj0681C8uML3PifYfREuBrVjDGhL3adYpBT6spw==",
+      "version": "1.0.30001706",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001706.tgz",
+      "integrity": "sha512-3ZczoTApMAZwPKYWmwVbQMFpXBDds3/0VciVoUwPUbldlYyVLmRVuRs/PcUZtHpbLRpzzDvrvnFuREsGt6lUug==",
       "funding": [
         {
           "type": "opencollective",
@@ -15219,6 +13822,44 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/chromium-edge-launcher": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/chromium-edge-launcher/-/chromium-edge-launcher-0.2.0.tgz",
+      "integrity": "sha512-JfJjUnq25y9yg4FABRRVPmBGWPZZi+AQXT4mxupb67766/0UlhG8PAZCz6xzEMXTbW3CsSoE8PcCWA49n35mKg==",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^1.0.0",
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "node_modules/chromium-edge-launcher/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chromium-edge-launcher/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "peer": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -15261,6 +13902,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
       "dependencies": {
         "restore-cursor": "^3.1.0"
       },
@@ -15272,6 +13914,7 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
       "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       },
@@ -15351,6 +13994,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -15437,12 +14081,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/command-exists": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
-      "peer": true
     },
     "node_modules/commander": {
       "version": "8.3.0",
@@ -15621,14 +14259,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
-    },
-    "node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
@@ -16236,12 +14866,6 @@
         "url": "https://opencollective.com/date-fns"
       }
     },
-    "node_modules/dayjs": {
-      "version": "1.11.12",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.12.tgz",
-      "integrity": "sha512-Rt2g+nTbLlDWZTwwrIXjy9MeiZmSDI375FvZs72ngxx8PDC6YXOeR3q5LAuPzjZQxhiWdRKac7RKV+YyQYfYIg==",
-      "peer": true
-    },
     "node_modules/debug": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
@@ -16256,15 +14880,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/decimal.js": {
@@ -16341,6 +14956,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
       "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
       "dependencies": {
         "clone": "^1.0.2"
       },
@@ -16395,12 +15011,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/denodeify": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
-      "integrity": "sha512-KNTihKNmQENUZeKu5fzfpzRqR5S2VMp4gl9RFHiWzj9DfvYQPMJ6XHKNaQxaGCXwPk6y9yme3aUoaiAe+KX+vg==",
-      "peer": true
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -16639,6 +15249,19 @@
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -16669,9 +15292,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.4.tgz",
-      "integrity": "sha512-orzA81VqLyIGUEA77YkVA1D+N+nNfl2isJVjjmOyrlxuooZ19ynb+dOlaDTqd/idKRS9lDCSBmtzM+kyCsMnkA=="
+      "version": "1.5.120",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.120.tgz",
+      "integrity": "sha512-oTUp3gfX1gZI+xfD2djr2rzQdHCwHzPQrrK0CD7WpTdF0nPdQ/INcRVjWgLdCT4a9W3jFObR9DAfsuyFQnI8CQ=="
     },
     "node_modules/emittery": {
       "version": "0.8.1",
@@ -16725,18 +15348,6 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/envinfo": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.13.0.tgz",
-      "integrity": "sha512-cvcaMr7KqXVh4nyzGTVqTum+gAiL265x5jUWQIDLq//zOGbW+gSW/C+OWLleY/rs9Qole6AZLMXPbtIFQbqu+Q==",
-      "peer": true,
-      "bin": {
-        "envinfo": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -16751,19 +15362,6 @@
       "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
       "dependencies": {
         "stackframe": "^1.3.4"
-      }
-    },
-    "node_modules/errorhandler": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.1.tgz",
-      "integrity": "sha512-rcOwbfvP1WTViVoUjcfZicVzjhjTuhSMntHh6mW3IrEiyE6mJyXvsToJUJGlGlw/2xU9P5whlWNGlIDVeCiT4A==",
-      "peer": true,
-      "dependencies": {
-        "accepts": "~1.3.7",
-        "escape-html": "~1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/es-abstract": {
@@ -16831,12 +15429,9 @@
       "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "engines": {
         "node": ">= 0.4"
       }
@@ -16903,9 +15498,9 @@
       "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw=="
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -16914,13 +15509,14 @@
       }
     },
     "node_modules/es-set-tostringtag": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "dependencies": {
-        "get-intrinsic": "^1.2.4",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.1"
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -16951,9 +15547,9 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "engines": {
         "node": ">=6"
       }
@@ -17740,6 +16336,12 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
+      "integrity": "sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==",
+      "peer": true
+    },
     "node_modules/express": {
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
@@ -18130,9 +16732,9 @@
       "peer": true
     },
     "node_modules/flow-parser": {
-      "version": "0.242.1",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.242.1.tgz",
-      "integrity": "sha512-E3ml21Q1S5cMAyPbtYslkvI6yZO5oCS/S2EoteeFH8Kx9iKOv/YOJ+dGd/yMf+H3YKfhMKjnOpyNwrO7NdddWA==",
+      "version": "0.265.3",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.265.3.tgz",
+      "integrity": "sha512-YH50TTYgnzDnuaZlAxLYQ0UZtXSbbizMO3OCpoY8obvLReJmvQ5UUW22efsC3SZJmze/tATfQ0PtkKul2XwWBw==",
       "peer": true,
       "engines": {
         "node": ">=0.4.0"
@@ -18501,15 +17103,20 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -18529,6 +17136,18 @@
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -18672,11 +17291,11 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -18763,9 +17382,9 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -18813,30 +17432,18 @@
       "dev": true
     },
     "node_modules/hermes-estree": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.19.1.tgz",
-      "integrity": "sha512-daLGV3Q2MKk8w4evNMKwS8zBE/rcpA800nu1Q5kM08IKijoSnPe9Uo1iIxzPKRkn95IxxsgBMPeYHt3VG4ej2g==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
       "peer": true
     },
     "node_modules/hermes-parser": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.19.1.tgz",
-      "integrity": "sha512-Vp+bXzxYJWrpEuJ/vXxUsLnt0+y4q9zyi4zUlkLqD8FKv4LjIfOvP69R/9Lty3dCyKh0E2BU7Eypqr63/rKT/A==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
       "peer": true,
       "dependencies": {
-        "hermes-estree": "0.19.1"
-      }
-    },
-    "node_modules/hermes-profile-transformer": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/hermes-profile-transformer/-/hermes-profile-transformer-0.0.6.tgz",
-      "integrity": "sha512-cnN7bQUm65UWOy6cbGcCcZ3rpwW8Q/j4OP5aWRhEry4Z2t2aR1cjrbp0BS+KiBN0smvP1caBgAuxutvyvJILzQ==",
-      "peer": true,
-      "dependencies": {
-        "source-map": "^0.7.3"
-      },
-      "engines": {
-        "node": ">=8"
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/hoopy": {
@@ -19153,9 +17760,9 @@
       }
     },
     "node_modules/image-size": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.1.1.tgz",
-      "integrity": "sha512-541xKlUw6jr/6gGuk92F+mYM5zaFAc5ahphvkqvNe2bQ6gVBkd6bfrmVJ2t4KDAfikAYZyIqTnktX3i6/aQDrQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.0.tgz",
+      "integrity": "sha512-4S8fwbO6w3GeCVN6OPtA9I5IGKkcDMPcKndtUlpJuCwu7JLjtj7JZpwqLuyY2nrmQT3AWsCJLSKPsc2mPBSl3w==",
       "peer": true,
       "dependencies": {
         "queue": "6.0.2"
@@ -19606,6 +18213,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -19827,6 +18435,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -21467,7 +20076,6 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
       "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
-      "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
@@ -22063,7 +20671,6 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
       "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
-      "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -23940,19 +22547,6 @@
         "jiti": "bin/jiti.js"
       }
     },
-    "node_modules/joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
-      "peer": true,
-      "dependencies": {
-        "@hapi/hoek": "^9.3.0",
-        "@hapi/topo": "^5.1.0",
-        "@sideway/address": "^4.1.5",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
-      }
-    },
     "node_modules/js-cookie": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
@@ -23984,12 +22578,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsc-android": {
-      "version": "250231.0.0",
-      "resolved": "https://registry.npmjs.org/jsc-android/-/jsc-android-250231.0.0.tgz",
-      "integrity": "sha512-rS46PvsjYmdmuz1OAWXY/1kCYG7pnf1TBqeTiOJr1iDz7s5DLxxC9n/ZMknLDxzYzNVfI7R95MH10emSSG1Wuw==",
-      "peer": true
-    },
     "node_modules/jsc-safe-url": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/jsc-safe-url/-/jsc-safe-url-0.2.4.tgz",
@@ -23997,117 +22585,77 @@
       "peer": true
     },
     "node_modules/jscodeshift": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.14.0.tgz",
-      "integrity": "sha512-7eCC1knD7bLUPuSCwXsMZUH51O8jIcoVyKtI6P0XM0IVzlGjckPy3FIwQlorzbN0Sg79oK+RlohN32Mqf/lrYA==",
+      "version": "17.1.2",
+      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-17.1.2.tgz",
+      "integrity": "sha512-uime4vFOiZ1o3ICT4Sm/AbItHEVw2oCxQ3a0egYVy3JMMOctxe07H3SKL1v175YqjMt27jn1N+3+Bj9SKDNgdQ==",
       "peer": true,
       "dependencies": {
-        "@babel/core": "^7.13.16",
-        "@babel/parser": "^7.13.16",
-        "@babel/plugin-proposal-class-properties": "^7.13.0",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.13.8",
-        "@babel/plugin-proposal-optional-chaining": "^7.13.12",
-        "@babel/plugin-transform-modules-commonjs": "^7.13.8",
-        "@babel/preset-flow": "^7.13.13",
-        "@babel/preset-typescript": "^7.13.0",
-        "@babel/register": "^7.13.16",
-        "babel-core": "^7.0.0-bridge.0",
-        "chalk": "^4.1.2",
+        "@babel/core": "^7.24.7",
+        "@babel/parser": "^7.24.7",
+        "@babel/plugin-transform-class-properties": "^7.24.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.7",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
+        "@babel/plugin-transform-optional-chaining": "^7.24.7",
+        "@babel/plugin-transform-private-methods": "^7.24.7",
+        "@babel/preset-flow": "^7.24.7",
+        "@babel/preset-typescript": "^7.24.7",
+        "@babel/register": "^7.24.6",
         "flow-parser": "0.*",
         "graceful-fs": "^4.2.4",
-        "micromatch": "^4.0.4",
+        "micromatch": "^4.0.7",
         "neo-async": "^2.5.0",
-        "node-dir": "^0.1.17",
-        "recast": "^0.21.0",
-        "temp": "^0.8.4",
-        "write-file-atomic": "^2.3.0"
+        "picocolors": "^1.0.1",
+        "recast": "^0.23.9",
+        "tmp": "^0.2.3",
+        "write-file-atomic": "^5.0.1"
       },
       "bin": {
         "jscodeshift": "bin/jscodeshift.js"
       },
+      "engines": {
+        "node": ">=16"
+      },
       "peerDependencies": {
         "@babel/preset-env": "^7.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/preset-env": {
+          "optional": true
+        }
       }
     },
-    "node_modules/jscodeshift/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+    "node_modules/jscodeshift/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=14"
       },
       "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/jscodeshift/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jscodeshift/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jscodeshift/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
-    },
-    "node_modules/jscodeshift/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+    "node_modules/jscodeshift/node_modules/tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
       "peer": true,
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jscodeshift/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">=14.14"
       }
     },
     "node_modules/jscodeshift/node_modules/write-file-atomic": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
       "peer": true,
       "dependencies": {
-        "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/jsdom": {
@@ -24180,14 +22728,14 @@
       }
     },
     "node_modules/jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "bin": {
         "jsesc": "bin/jsesc"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=6"
       }
     },
     "node_modules/json-buffer": {
@@ -24474,6 +23022,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
@@ -24489,6 +23038,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -24503,6 +23053,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -24518,6 +23069,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -24528,12 +23080,14 @@
     "node_modules/log-symbols/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/log-symbols/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -24542,77 +23096,12 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/logkitty": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/logkitty/-/logkitty-0.7.1.tgz",
-      "integrity": "sha512-/3ER20CTTbahrCrpYfPn7Xavv9diBROZpoXGVZDWMw4b/X4uuUwAC0ki85tgsdMRONURyIJbcOvS94QsUBYPbQ==",
-      "peer": true,
-      "dependencies": {
-        "ansi-fragments": "^0.2.1",
-        "dayjs": "^1.8.15",
-        "yargs": "^15.1.0"
-      },
-      "bin": {
-        "logkitty": "bin/logkitty.js"
-      }
-    },
-    "node_modules/logkitty/node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "peer": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
-      }
-    },
-    "node_modules/logkitty/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "peer": true
-    },
-    "node_modules/logkitty/node_modules/yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-      "peer": true,
-      "dependencies": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/logkitty/node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "peer": true,
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/loose-envify": {
@@ -24703,6 +23192,14 @@
       "integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==",
       "peer": true
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -24763,129 +23260,117 @@
       }
     },
     "node_modules/metro": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.80.9.tgz",
-      "integrity": "sha512-Bc57Xf3GO2Xe4UWQsBj/oW6YfLPABEu8jfDVDiNmJvoQW4CO34oDPuYKe4KlXzXhcuNsqOtSxpbjCRRVjhhREg==",
+      "version": "0.81.3",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.81.3.tgz",
+      "integrity": "sha512-upilFs7z1uLKvdzFYHiVKrGT/uC7h7d53R0g/FaJoQvLfA8jQG2V69jeOcGi4wCsFYvl1zBSZvKxpQb0nA3giQ==",
       "peer": true,
       "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/core": "^7.20.0",
-        "@babel/generator": "^7.20.0",
-        "@babel/parser": "^7.20.0",
-        "@babel/template": "^7.0.0",
-        "@babel/traverse": "^7.20.0",
-        "@babel/types": "^7.20.0",
+        "@babel/code-frame": "^7.24.7",
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.25.0",
+        "@babel/parser": "^7.25.3",
+        "@babel/template": "^7.25.0",
+        "@babel/traverse": "^7.25.3",
+        "@babel/types": "^7.25.2",
         "accepts": "^1.3.7",
         "chalk": "^4.0.0",
         "ci-info": "^2.0.0",
         "connect": "^3.6.5",
         "debug": "^2.2.0",
-        "denodeify": "^1.2.1",
         "error-stack-parser": "^2.0.6",
+        "flow-enums-runtime": "^0.0.6",
         "graceful-fs": "^4.2.4",
-        "hermes-parser": "0.20.1",
+        "hermes-parser": "0.25.1",
         "image-size": "^1.0.2",
         "invariant": "^2.2.4",
-        "jest-worker": "^29.6.3",
+        "jest-worker": "^29.7.0",
         "jsc-safe-url": "^0.2.2",
         "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.80.9",
-        "metro-cache": "0.80.9",
-        "metro-cache-key": "0.80.9",
-        "metro-config": "0.80.9",
-        "metro-core": "0.80.9",
-        "metro-file-map": "0.80.9",
-        "metro-resolver": "0.80.9",
-        "metro-runtime": "0.80.9",
-        "metro-source-map": "0.80.9",
-        "metro-symbolicate": "0.80.9",
-        "metro-transform-plugins": "0.80.9",
-        "metro-transform-worker": "0.80.9",
+        "metro-babel-transformer": "0.81.3",
+        "metro-cache": "0.81.3",
+        "metro-cache-key": "0.81.3",
+        "metro-config": "0.81.3",
+        "metro-core": "0.81.3",
+        "metro-file-map": "0.81.3",
+        "metro-resolver": "0.81.3",
+        "metro-runtime": "0.81.3",
+        "metro-source-map": "0.81.3",
+        "metro-symbolicate": "0.81.3",
+        "metro-transform-plugins": "0.81.3",
+        "metro-transform-worker": "0.81.3",
         "mime-types": "^2.1.27",
-        "node-fetch": "^2.2.0",
         "nullthrows": "^1.1.1",
-        "rimraf": "^3.0.2",
         "serialize-error": "^2.1.0",
         "source-map": "^0.5.6",
-        "strip-ansi": "^6.0.0",
         "throat": "^5.0.0",
-        "ws": "^7.5.1",
+        "ws": "^7.5.10",
         "yargs": "^17.6.2"
       },
       "bin": {
         "metro": "src/cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18.18"
       }
     },
     "node_modules/metro-babel-transformer": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.80.9.tgz",
-      "integrity": "sha512-d76BSm64KZam1nifRZlNJmtwIgAeZhZG3fi3K+EmPOlrR8rDtBxQHDSN3fSGeNB9CirdTyabTMQCkCup6BXFSQ==",
+      "version": "0.81.3",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.81.3.tgz",
+      "integrity": "sha512-ENqtnPy2mQZFOuKrbqHRcAwZuaYe43X+30xIF0xlkLuMyCvc0CsFzrrSK9EqrQwexhVlqaRALb0GQbBMcE/y8g==",
       "peer": true,
       "dependencies": {
-        "@babel/core": "^7.20.0",
-        "hermes-parser": "0.20.1",
+        "@babel/core": "^7.25.2",
+        "flow-enums-runtime": "^0.0.6",
+        "hermes-parser": "0.25.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/metro-babel-transformer/node_modules/hermes-estree": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.20.1.tgz",
-      "integrity": "sha512-SQpZK4BzR48kuOg0v4pb3EAGNclzIlqMj3Opu/mu7bbAoFw6oig6cEt/RAi0zTFW/iW6Iz9X9ggGuZTAZ/yZHg==",
-      "peer": true
-    },
-    "node_modules/metro-babel-transformer/node_modules/hermes-parser": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.20.1.tgz",
-      "integrity": "sha512-BL5P83cwCogI8D7rrDCgsFY0tdYUtmFP9XaXtl2IQjC+2Xo+4okjfXintlTxcIwl4qeGddEl28Z11kbVIw0aNA==",
-      "peer": true,
-      "dependencies": {
-        "hermes-estree": "0.20.1"
+        "node": ">=18.18"
       }
     },
     "node_modules/metro-cache": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.80.9.tgz",
-      "integrity": "sha512-ujEdSI43QwI+Dj2xuNax8LMo8UgKuXJEdxJkzGPU6iIx42nYa1byQ+aADv/iPh5sh5a//h5FopraW5voXSgm2w==",
+      "version": "0.81.3",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.81.3.tgz",
+      "integrity": "sha512-6UelMQYjlto/79tTXu0vsTxAX4e+Bkf0tgtDL1BNx3wd68pBg8qKIYpJPaUlOIaNUzFXTBDjYwUverkEW0KAtA==",
       "peer": true,
       "dependencies": {
-        "metro-core": "0.80.9",
-        "rimraf": "^3.0.2"
+        "exponential-backoff": "^3.1.1",
+        "flow-enums-runtime": "^0.0.6",
+        "metro-core": "0.81.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18.18"
       }
     },
     "node_modules/metro-cache-key": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.80.9.tgz",
-      "integrity": "sha512-hRcYGhEiWIdM87hU0fBlcGr+tHDEAT+7LYNCW89p5JhErFt/QaAkVx4fb5bW3YtXGv5BTV7AspWPERoIb99CXg==",
+      "version": "0.81.3",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.81.3.tgz",
+      "integrity": "sha512-KPsPSRUd6uRva7k7k/DqiiD8td7URQWx0RkX/Cj5+bed5zSXEg/XoQA+b+DmMxS5C7TqP61Fh3XvHx6TQRW82A==",
       "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
       "engines": {
-        "node": ">=18"
+        "node": ">=18.18"
       }
     },
     "node_modules/metro-config": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.80.9.tgz",
-      "integrity": "sha512-28wW7CqS3eJrunRGnsibWldqgwRP9ywBEf7kg+uzUHkSFJNKPM1K3UNSngHmH0EZjomizqQA2Zi6/y6VdZMolg==",
+      "version": "0.81.3",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.81.3.tgz",
+      "integrity": "sha512-WpTaT0iQr5juVY50Y/cyacG2ggZqF38VshEQepT+ovPK8E/xUVxlbO5yxLSXUxxUXX3Hka9r6g64+y2WC6c/xQ==",
       "peer": true,
       "dependencies": {
         "connect": "^3.6.5",
         "cosmiconfig": "^5.0.5",
-        "jest-validate": "^29.6.3",
-        "metro": "0.80.9",
-        "metro-cache": "0.80.9",
-        "metro-core": "0.80.9",
-        "metro-runtime": "0.80.9"
+        "flow-enums-runtime": "^0.0.6",
+        "jest-validate": "^29.7.0",
+        "metro": "0.81.3",
+        "metro-cache": "0.81.3",
+        "metro-core": "0.81.3",
+        "metro-runtime": "0.81.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18.18"
       }
     },
     "node_modules/metro-config/node_modules/ansi-styles": {
@@ -25070,40 +23555,37 @@
       }
     },
     "node_modules/metro-core": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.80.9.tgz",
-      "integrity": "sha512-tbltWQn+XTdULkGdzHIxlxk4SdnKxttvQQV3wpqqFbHDteR4gwCyTR2RyYJvxgU7HELfHtrVbqgqAdlPByUSbg==",
+      "version": "0.81.3",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.81.3.tgz",
+      "integrity": "sha512-WZ+qohnpvvSWdPj1VJPUrZz+2ik29M+UUpMU6YrmzQUfDyZ6JYHhzlw5WVBtwpt/+2xTsIyrZ2C1fByT/DsLQA==",
       "peer": true,
       "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.80.9"
+        "metro-resolver": "0.81.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18.18"
       }
     },
     "node_modules/metro-file-map": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.80.9.tgz",
-      "integrity": "sha512-sBUjVtQMHagItJH/wGU9sn3k2u0nrCl0CdR4SFMO1tksXLKbkigyQx4cbpcyPVOAmGTVuy3jyvBlELaGCAhplQ==",
+      "version": "0.81.3",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.81.3.tgz",
+      "integrity": "sha512-F+t4lnVRoauJxtr9xmI4pWIOE77/vl0IrHDGeJSI9cW6LmuqxkpOlZHTKpbs/hMAo6+KhG2JMJACQDvXDLd/GA==",
       "peer": true,
       "dependencies": {
-        "anymatch": "^3.0.3",
         "debug": "^2.2.0",
         "fb-watchman": "^2.0.0",
+        "flow-enums-runtime": "^0.0.6",
         "graceful-fs": "^4.2.4",
         "invariant": "^2.2.4",
-        "jest-worker": "^29.6.3",
+        "jest-worker": "^29.7.0",
         "micromatch": "^4.0.4",
-        "node-abort-controller": "^3.1.1",
         "nullthrows": "^1.1.1",
         "walker": "^1.0.7"
       },
       "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.2"
+        "node": ">=18.18"
       }
     },
     "node_modules/metro-file-map/node_modules/debug": {
@@ -25122,55 +23604,62 @@
       "peer": true
     },
     "node_modules/metro-minify-terser": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.80.9.tgz",
-      "integrity": "sha512-FEeCeFbkvvPuhjixZ1FYrXtO0araTpV6UbcnGgDUpH7s7eR5FG/PiJz3TsuuPP/HwCK19cZtQydcA2QrCw446A==",
+      "version": "0.81.3",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.81.3.tgz",
+      "integrity": "sha512-912AYv3OmwcbUwzCdWbdQRk+RV6kXXluHKlhBdYFD3kr4Ece691rzlofU/Mlt9qZrhHtctD5Q8cFqOEf9Z69bQ==",
       "peer": true,
       "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
         "terser": "^5.15.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18.18"
       }
     },
     "node_modules/metro-resolver": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.80.9.tgz",
-      "integrity": "sha512-wAPIjkN59BQN6gocVsAvvpZ1+LQkkqUaswlT++cJafE/e54GoVkMNCmrR4BsgQHr9DknZ5Um/nKueeN7kaEz9w==",
+      "version": "0.81.3",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.81.3.tgz",
+      "integrity": "sha512-XnjENY1c6jcsEfFVIjN/8McUIInCVgGxv5eva+9ZWeCTyiAE/L5HPj2ai/Myb349+6QuSMR0dscTkKCnOwWXdw==",
       "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
       "engines": {
-        "node": ">=18"
+        "node": ">=18.18"
       }
     },
     "node_modules/metro-runtime": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.80.9.tgz",
-      "integrity": "sha512-8PTVIgrVcyU+X/rVCy/9yxNlvXsBCk5JwwkbAm/Dm+Abo6NBGtNjWF0M1Xo/NWCb4phamNWcD7cHdR91HhbJvg==",
+      "version": "0.81.3",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.81.3.tgz",
+      "integrity": "sha512-neuGRMC2pgGKIFPbmbrxW41/SmvL7OX4i1LN+saUY2t1cZfxf9haQHUMCGhO3498uEL2N+ulKRSlQrHt6XwGaw==",
       "peer": true,
       "dependencies": {
-        "@babel/runtime": "^7.0.0"
+        "@babel/runtime": "^7.25.0",
+        "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18.18"
       }
     },
     "node_modules/metro-source-map": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.80.9.tgz",
-      "integrity": "sha512-RMn+XS4VTJIwMPOUSj61xlxgBvPeY4G6s5uIn6kt6HB6A/k9ekhr65UkkDD7WzHYs3a9o869qU8tvOZvqeQzgw==",
+      "version": "0.81.3",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.81.3.tgz",
+      "integrity": "sha512-BHJJurmDQRn3hCbBawh/UHzPz3duMpwpE3ofImO2DoWHYzn6nSg/D4wfCN4y14d9fFLE4e0I+BAOX1HWNP4jsw==",
       "peer": true,
       "dependencies": {
-        "@babel/traverse": "^7.20.0",
-        "@babel/types": "^7.20.0",
+        "@babel/traverse": "^7.25.3",
+        "@babel/traverse--for-generate-function-map": "npm:@babel/traverse@^7.25.3",
+        "@babel/types": "^7.25.2",
+        "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.80.9",
+        "metro-symbolicate": "0.81.3",
         "nullthrows": "^1.1.1",
-        "ob1": "0.80.9",
+        "ob1": "0.81.3",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18.18"
       }
     },
     "node_modules/metro-source-map/node_modules/source-map": {
@@ -25183,23 +23672,23 @@
       }
     },
     "node_modules/metro-symbolicate": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.80.9.tgz",
-      "integrity": "sha512-Ykae12rdqSs98hg41RKEToojuIW85wNdmSe/eHUgMkzbvCFNVgcC0w3dKZEhSsqQOXapXRlLtHkaHLil0UD/EA==",
+      "version": "0.81.3",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.81.3.tgz",
+      "integrity": "sha512-LQLT6WopQmIz2SDSVh3Lw7nLzF58HpsrPYqRB7RpRXBYhYmPFIjiGaP8qqtKHXczM/5YAOJzpgt8t/OGZgh6Eg==",
       "peer": true,
       "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-source-map": "0.80.9",
+        "metro-source-map": "0.81.3",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
-        "through2": "^2.0.1",
         "vlq": "^1.0.0"
       },
       "bin": {
         "metro-symbolicate": "src/index.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18.18"
       }
     },
     "node_modules/metro-symbolicate/node_modules/source-map": {
@@ -25212,42 +23701,44 @@
       }
     },
     "node_modules/metro-transform-plugins": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.80.9.tgz",
-      "integrity": "sha512-UlDk/uc8UdfLNJhPbF3tvwajyuuygBcyp+yBuS/q0z3QSuN/EbLllY3rK8OTD9n4h00qZ/qgxGv/lMFJkwP4vg==",
+      "version": "0.81.3",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.81.3.tgz",
+      "integrity": "sha512-4JMUXhBB5y4h3dyA272k7T7+U3+J4fSBcct0Y8Yur9ziZB/dK8fieEQg5ZPfEGsgOGI+54zTzOUqga6AgmZSNg==",
       "peer": true,
       "dependencies": {
-        "@babel/core": "^7.20.0",
-        "@babel/generator": "^7.20.0",
-        "@babel/template": "^7.0.0",
-        "@babel/traverse": "^7.20.0",
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.25.0",
+        "@babel/template": "^7.25.0",
+        "@babel/traverse": "^7.25.3",
+        "flow-enums-runtime": "^0.0.6",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18.18"
       }
     },
     "node_modules/metro-transform-worker": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.80.9.tgz",
-      "integrity": "sha512-c/IrzMUVnI0hSVVit4TXzt3A1GiUltGVlzCmLJWxNrBGHGrJhvgePj38+GXl1Xf4Fd4vx6qLUkKMQ3ux73bFLQ==",
+      "version": "0.81.3",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.81.3.tgz",
+      "integrity": "sha512-KZqm9sVyBKRygUxRm+yP4DguE9R1EEv28KJhIxghNp5dcdVXBYUPe1xHoc3QVdzD9c3tf8JFzA2FBlKTlwMwNg==",
       "peer": true,
       "dependencies": {
-        "@babel/core": "^7.20.0",
-        "@babel/generator": "^7.20.0",
-        "@babel/parser": "^7.20.0",
-        "@babel/types": "^7.20.0",
-        "metro": "0.80.9",
-        "metro-babel-transformer": "0.80.9",
-        "metro-cache": "0.80.9",
-        "metro-cache-key": "0.80.9",
-        "metro-minify-terser": "0.80.9",
-        "metro-source-map": "0.80.9",
-        "metro-transform-plugins": "0.80.9",
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.25.0",
+        "@babel/parser": "^7.25.3",
+        "@babel/types": "^7.25.2",
+        "flow-enums-runtime": "^0.0.6",
+        "metro": "0.81.3",
+        "metro-babel-transformer": "0.81.3",
+        "metro-cache": "0.81.3",
+        "metro-cache-key": "0.81.3",
+        "metro-minify-terser": "0.81.3",
+        "metro-source-map": "0.81.3",
+        "metro-transform-plugins": "0.81.3",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18.18"
       }
     },
     "node_modules/metro/node_modules/ansi-styles": {
@@ -25321,21 +23812,6 @@
       "peer": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/metro/node_modules/hermes-estree": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.20.1.tgz",
-      "integrity": "sha512-SQpZK4BzR48kuOg0v4pb3EAGNclzIlqMj3Opu/mu7bbAoFw6oig6cEt/RAi0zTFW/iW6Iz9X9ggGuZTAZ/yZHg==",
-      "peer": true
-    },
-    "node_modules/metro/node_modules/hermes-parser": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.20.1.tgz",
-      "integrity": "sha512-BL5P83cwCogI8D7rrDCgsFY0tdYUtmFP9XaXtl2IQjC+2Xo+4okjfXintlTxcIwl4qeGddEl28Z11kbVIw0aNA==",
-      "peer": true,
-      "dependencies": {
-        "hermes-estree": "0.20.1"
       }
     },
     "node_modules/metro/node_modules/ms": {
@@ -25603,6 +24079,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/msw/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/msw/node_modules/graphql": {
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
@@ -25715,33 +24200,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
-    "node_modules/nocache": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/nocache/-/nocache-3.0.4.tgz",
-      "integrity": "sha512-WDD0bdg9mbq6F4mRxEYcPWwfA1vxd0mrvKOyxI7Xj/atfRHVeutzuWByG//jfm4uPzp0y4Kj051EORCBSQMycw==",
-      "peer": true,
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/node-abort-controller": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
-      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
-      "peer": true
-    },
-    "node_modules/node-dir": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
-      "integrity": "sha512-tmPX422rYgofd4epzrNoOXiE8XFZYOcCq1vD7MAXCDO+O+zndlA2ztdKKMa+EeuBG5tHETpr4ml4RGgpqDCCAg==",
-      "peer": true,
-      "dependencies": {
-        "minimatch": "^3.0.2"
-      },
-      "engines": {
-        "node": ">= 0.10.5"
-      }
-    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -25775,22 +24233,9 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
     },
     "node_modules/node-releases": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
-    },
-    "node_modules/node-stream-zip": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
-      "integrity": "sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.12.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/antelle"
-      }
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -25853,12 +24298,15 @@
       "integrity": "sha512-qXDmcVlZV4XRtKFzddidpfVP4oMSGhga+xdMc25mv8kaLUHtgzCDhUxkrN8exkGdTlLNaXj7CV3GtON7zuGZ+w=="
     },
     "node_modules/ob1": {
-      "version": "0.80.9",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.80.9.tgz",
-      "integrity": "sha512-v9yOxowkZbxWhKOaaTyLjIm1aLy4ebMNcSn4NYJKOAI/Qv+SkfEfszpLr2GIxsccmb2Y2HA9qtsqiIJ80ucpVA==",
+      "version": "0.81.3",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.81.3.tgz",
+      "integrity": "sha512-wd8zdH0DWsn2iDVn2zT/QURihcqoc73K8FhNCmQ16qkJaoYJLNb/N+huOwdCgsbNP8Lk/s1+dPnDETx+RzsrWA==",
       "peer": true,
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
       "engines": {
-        "node": ">=18"
+        "node": ">=18.18"
       }
     },
     "node_modules/object-assign": {
@@ -26089,6 +24537,7 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
       "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
       "dependencies": {
         "bl": "^4.1.0",
         "chalk": "^4.1.0",
@@ -26111,6 +24560,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -26125,6 +24575,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -26140,6 +24591,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -26150,12 +24602,14 @@
     "node_modules/ora/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/ora/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -26164,6 +24618,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -26379,9 +24834,9 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -28175,9 +26630,9 @@
       }
     },
     "node_modules/react-devtools-core": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-5.3.1.tgz",
-      "integrity": "sha512-7FSb9meX0btdBQLwdFOwt6bGqvRPabmVMMslv8fgoSPqXyuGpgQe36kx8gR86XPw7aV1yVouTp6fyZ0EH+NfUw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.1.tgz",
+      "integrity": "sha512-TFo1MEnkqE6hzAbaztnyR5uLTMoz6wnEWwWBsCUzNt+sVXJycuRJdDqvL078M4/h65BI/YO5XWTaxZDWVsW0fw==",
       "peer": true,
       "dependencies": {
         "shell-quote": "^1.6.1",
@@ -28632,19 +27087,6 @@
         "typedarray-to-buffer": "^3.1.5"
       }
     },
-    "node_modules/react-shallow-renderer": {
-      "version": "16.15.0",
-      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
-      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
-      "peer": true,
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -28699,14 +27141,15 @@
       "peer": true
     },
     "node_modules/recast": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.21.5.tgz",
-      "integrity": "sha512-hjMmLaUXAm1hIuTqOdeYObMslq/q+Xff6QE3Y2P+uoHAg2nmVlLBps2hzh1UJDdMtDTMXOFewK6ky51JQIeECg==",
+      "version": "0.23.11",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
+      "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
       "peer": true,
       "dependencies": {
-        "ast-types": "0.15.2",
+        "ast-types": "^0.16.1",
         "esprima": "~4.0.0",
         "source-map": "~0.6.1",
+        "tiny-invariant": "^1.3.3",
         "tslib": "^2.0.1"
       },
       "engines": {
@@ -28723,9 +27166,9 @@
       }
     },
     "node_modules/recast/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "peer": true
     },
     "node_modules/recursive-readdir": {
@@ -28894,12 +27337,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "peer": true
-    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -29019,6 +27456,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -29526,12 +27964,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "peer": true
-    },
     "node_modules/set-cookie-parser": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
@@ -29645,29 +28077,6 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/slice-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
-      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.0",
-        "astral-regex": "^1.0.0",
-        "is-fullwidth-code-point": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/sockjs": {
@@ -29827,9 +28236,9 @@
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
     },
     "node_modules/stacktrace-parser": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.10.tgz",
-      "integrity": "sha512-KJP1OCML99+8fhOHxwwzyWrlUuVX5GQ0ZpJTd1DFXhdkrvg1szxfHhawXUZ3g9TkXORQd4/WG68jMlQZ2p8wlg==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.11.tgz",
+      "integrity": "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==",
       "peer": true,
       "dependencies": {
         "type-fest": "^0.7.1"
@@ -30200,9 +28609,15 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ]
     },
     "node_modules/style-loader": {
       "version": "3.3.4",
@@ -30303,12 +28718,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/sudo-prompt": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-9.2.1.tgz",
-      "integrity": "sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==",
-      "peer": true
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -30455,37 +28864,12 @@
         "node": ">=6"
       }
     },
-    "node_modules/temp": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.4.tgz",
-      "integrity": "sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==",
-      "peer": true,
-      "dependencies": {
-        "rimraf": "~2.6.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
       "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/temp/node_modules/rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "peer": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
       }
     },
     "node_modules/tempy": {
@@ -30686,50 +29070,16 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
-    "node_modules/through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "peer": true,
-      "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
-    },
-    "node_modules/through2/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "peer": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/through2/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "peer": true
-    },
-    "node_modules/through2/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/thunky": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "peer": true
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -31070,18 +29420,26 @@
       }
     },
     "node_modules/universal-cookie": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
-      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-7.2.2.tgz",
+      "integrity": "sha512-fMiOcS3TmzP2x5QV26pIH3mvhexLIT0HmPa3V7Q7knRfT9HG6kTwq02HZGLPw0sAOXrAmotElGRvTLCMbJsvxQ==",
       "dependencies": {
-        "@types/cookie": "^0.3.3",
-        "cookie": "^0.4.0"
+        "@types/cookie": "^0.6.0",
+        "cookie": "^0.7.2"
       }
     },
     "node_modules/universal-cookie/node_modules/@types/cookie": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
-      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
+    },
+    "node_modules/universal-cookie/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -31114,9 +29472,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
-      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
       "funding": [
         {
           "type": "opencollective",
@@ -31132,8 +29490,8 @@
         }
       ],
       "dependencies": {
-        "escalade": "^3.1.2",
-        "picocolors": "^1.0.1"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -31362,6 +29720,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
       "dependencies": {
         "defaults": "^1.0.3"
       }
@@ -31922,12 +30281,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/which-module": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
-      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
-      "peer": true
-    },
     "node_modules/which-typed-array": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
@@ -32264,6 +30617,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -32324,6 +30678,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -32338,6 +30693,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -32348,7 +30704,8 @@
     "node_modules/wrap-ansi/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
@@ -32359,7 +30716,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-      "dev": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
@@ -32397,15 +30753,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.4"
-      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/source/ui/package.json
+++ b/source/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "network-orchestrator-for-aws-transit-gateway",
-  "version": "3.3.14",
+  "version": "3.3.15",
   "description": "Network Orchestration for AWS Transit Gateway(SO0058)",
   "license": "Apache-2.0",
   "author": {
@@ -89,6 +89,9 @@
   "overrides": {
     "svgo": {
       "css-select": "~4.3.0"
+    },
+    "msw": {
+      "cookie": "~0.7.2"
     },
     "fast-xml-parser": "4.4.1",
     "resolve-url-loader": {

--- a/source/ui/src/graphql/function/Mutation_UpdateDDBTableAppSyncFunction_Response
+++ b/source/ui/src/graphql/function/Mutation_UpdateDDBTableAppSyncFunction_Response
@@ -1,6 +1,11 @@
 ## Raise a GraphQL field error in case of a datasource invocation error
 #if($ctx.error)
-    $util.error($ctx.error.message, $ctx.error.type)
+    $util.log.error($util.toJson($ctx.error))
+    #if($ctx.error.type == "DynamoDB:ConditionalCheckFailedException")
+        $util.error("Invalid input", "BadRequest")
+    #else
+        $util.error("Unknown error encountered, please review logs", "UnknownError")
+    #end
 #end
 ## Pass back the result from DynamoDB. **
 $util.toJson($ctx.result)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Bump aws-amplify to `5.3.27`
- Allow only TLS requests on S3 bucket through bucket policy
- Add CSP security headers on CloudFront
- Enable MFA for authentication by default
- Add [AWS Managed WAF rules](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html) to ACL
- Update nodejs lambda runtime to `22.x`
- Disable introspection queries on AppSync API
- Disable verbose logging on the AppSync API
- Update AppRegistry application tags at resource level
- Remove unused http methods from cache behavior, Cloudfront only needs to process and forward GET/HEAD requests to S3 origin
- Improve error response for `UpdateTransitNetworkOrchestratorTable` API path

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
