### PR TITLE
Bump image-size

### DIFF
--- a/source/ui/package-lock.json
+++ b/source/ui/package-lock.json
@@ -17760,9 +17760,10 @@
       }
     },
     "node_modules/image-size": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.0.tgz",
-      "integrity": "sha512-4S8fwbO6w3GeCVN6OPtA9I5IGKkcDMPcKndtUlpJuCwu7JLjtj7JZpwqLuyY2nrmQT3AWsCJLSKPsc2mPBSl3w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "queue": "6.0.2"


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Addresses - https://github.com/advisories/GHSA-m5qc-5hw7-8vg7
- Bumps [image-size](https://github.com/image-size/image-size) from 1.2.0 to 1.2.1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
